### PR TITLE
refactor: enhance Keyword entity with source and lifecycle flags

### DIFF
--- a/src/main/java/com/palangwi/soup/domain/keyword/Keyword.java
+++ b/src/main/java/com/palangwi/soup/domain/keyword/Keyword.java
@@ -7,13 +7,15 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "keyword")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Keyword extends BaseEntity {
 
     @Id
@@ -23,4 +25,29 @@ public class Keyword extends BaseEntity {
     private String name;
 
     private String normalizedName;
+
+    private Source source;
+
+    private boolean visible;
+
+    private boolean deleted;
+
+    public static Keyword generateKeyword(String name, String normalizedName, Source source) {
+        return Keyword.builder()
+                .name(name)
+                .normalizedName(normalizedName)
+                .source(source)
+                .visible(true)
+                .deleted(false)
+                .build();
+    }
+
+    @Builder
+    private Keyword(String name, String normalizedName, Source source, boolean visible, boolean deleted) {
+        this.name = name;
+        this.normalizedName = normalizedName;
+        this.source = source;
+        this.visible = visible;
+        this.deleted = deleted;
+    }
 }

--- a/src/main/java/com/palangwi/soup/domain/keyword/Source.java
+++ b/src/main/java/com/palangwi/soup/domain/keyword/Source.java
@@ -1,0 +1,7 @@
+package com.palangwi.soup.domain.keyword;
+
+public enum Source {
+    MANUAL, // 수동
+    AUTO, // 자동
+    USER_REQUEST // 사용자 요청
+}


### PR DESCRIPTION
## 주요 변경 사항
- Keyword 도메인에 `source`, `visible`, `deleted` 필드 추가
  - `source`: 키워드의 생성 출처 (`MANUAL`, `AUTO`, `USER_REQUEST`)를 나타내는 enum
  - `visible`: 사용자에게 노출 여부를 제어하는 플래그
  - `deleted`: soft delete 처리를 위한 상태 플래그
- Builder 패턴 및 static 팩토리 메서드 (`generateKeyword`) 추가하여 객체 생성 일관성 강화

## 관련 파일
- `Keyword.java`: 필드 추가 및 빌더 생성자, 정적 팩토리 메서드 구현
- `Source.java`: 키워드 출처를 구분하는 enum 클래스 신규 생성

## 특이사항
- soft delete 관련 기능은 향후 서비스/레포지토리 계층에서 쿼리 분리 또는 필터 적용 방식으로 대응 예정

## 리뷰 요청 사항
- Keyword 엔티티 구조가 도메인 설계 의도에 부합하는지 검토 부탁드립니다
- soft delete 및 visible 플래그 활용 방식에 대한 추가적인 의견이 있다면 공유 부탁드립니다
- enum `Source` 값 구성에 누락된 케이스가 있다면 알려주세요

감사합니다. 🙇