### PR TITLE
refactor: Replace visible/deleted flags with Status enum in Keyword

### DIFF
--- a/src/main/java/com/palangwi/soup/domain/keyword/Keyword.java
+++ b/src/main/java/com/palangwi/soup/domain/keyword/Keyword.java
@@ -31,27 +31,24 @@ public class Keyword extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Source source;
 
-    private boolean visible;
+    @Enumerated(EnumType.STRING)
+    private Status status;
 
-    private boolean deleted;
-
-    public static Keyword generateKeyword(String name, String normalizedName, Source source) {
+    public static Keyword of(String name, String normalizedName, Source source) {
         return Keyword.builder()
                 .name(name)
                 .normalizedName(normalizedName)
                 .source(source)
-                .visible(true)
-                .deleted(false)
+                .status(Status.ACTIVE)
                 .build();
     }
 
     @Builder
-    private Keyword(String name, String normalizedName, Source source, boolean visible, boolean deleted) {
+    private Keyword(String name, String normalizedName, Source source, Status status) {
         this.name = name;
         this.normalizedName = normalizedName;
         this.source = source;
-        this.visible = visible;
-        this.deleted = deleted;
+        this.status = status;
     }
 
     // 추후 Keyword 도메인을 분리하게 된다면, 구독중인 사용자의 수를 어떻게 관리할 지 논의가 필요할 것 같습니다.

--- a/src/main/java/com/palangwi/soup/domain/keyword/Status.java
+++ b/src/main/java/com/palangwi/soup/domain/keyword/Status.java
@@ -1,0 +1,7 @@
+package com.palangwi.soup.domain.keyword;
+
+public enum Status {
+    ACTIVE, // 활성
+    INACTIVE, // 비활성
+    DELETED // 삭제
+}


### PR DESCRIPTION
## 주요 변경사항
- `Keyword` 엔티티에서 `visible`, `deleted` 필드를 제거하고 `Status` Enum(`ACTIVE`, `INACTIVE`, `DELETED`)으로 통합했습니다.
- 키워드 생성 팩토리 메서드명을 `generateKeyword` → `of`로 변경했습니다.
- 생성자 수정: `visible`, `deleted` 대신 `status`만 관리하도록 리팩터링했습니다.
- `Status` Enum 클래스를 새로 추가했습니다.

## 변경 이유
- 키워드 상태 관리 일관성을 위해 Boolean 필드 대신 명시적인 Enum 타입으로 관리 체계를 통합했습니다.
- 추후 키워드 비활성화, 삭제 복구 등의 기능 확장에 대비해 상태 흐름을 명확히 표현하기 위함입니다.

## 관련 파일
- `Keyword.java`
- `Status.java`

## 기타
- 키워드 생성 시 기본 상태는 `Status.ACTIVE`로 설정됩니다.