### PR TITLE
[feat] 이메일 트래킹 기능 구현

### DIFF
--- a/src/main/java/com/palangwi/soup/controller/mail/MailController.java
+++ b/src/main/java/com/palangwi/soup/controller/mail/MailController.java
@@ -1,0 +1,29 @@
+package com.palangwi.soup.controller.mail;
+
+import com.palangwi.soup.service.mail.MailService;
+import com.palangwi.soup.utils.ApiUtils.ApiResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mails")
+public class MailController {
+
+    private final MailService mailService;
+
+    @GetMapping("/traking/open/{mailId}")
+    public ResponseEntity<byte[]> trakingMail(@PathVariable("mailId") Long mailId) {
+        byte[] pixel = mailService.trackingMail(mailId);
+
+        return ResponseEntity.ok()
+                .header("Content-Type", "image/png")
+                .body(pixel);
+    }
+
+}

--- a/src/main/java/com/palangwi/soup/domain/mail/MailEvent.java
+++ b/src/main/java/com/palangwi/soup/domain/mail/MailEvent.java
@@ -60,6 +60,8 @@ public class MailEvent extends BaseEntity {
     }
 
     public void markAsOpen() {
+        if (this.opened) return;
+
         this.opened = true;
         this.openedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/palangwi/soup/infrastructure/mail/MailViewRenderer.java
+++ b/src/main/java/com/palangwi/soup/infrastructure/mail/MailViewRenderer.java
@@ -23,7 +23,7 @@ public class MailViewRenderer {
         Context context = new Context();
         context.setVariable("name", username);
         context.setVariable("summaries", summaries);
-        context.setVariable("trackingUrl", "https://trackingUrl-example.com/read?eventId=" + mailEventId);
+        context.setVariable("trackingUrl", "https://my-homepage/read?eventId=" + mailEventId);
         // resources/templates/mail/daily-news.html 파일에 적용
         return templateEngine.process("mail/daily-news", context);
     }

--- a/src/main/java/com/palangwi/soup/service/mail/MailService.java
+++ b/src/main/java/com/palangwi/soup/service/mail/MailService.java
@@ -1,7 +1,6 @@
 package com.palangwi.soup.service.mail;
 
 import com.palangwi.soup.domain.mail.MailEvent;
-import com.palangwi.soup.domain.mail.MailType;
 import com.palangwi.soup.domain.mail.policy.NewsSelectionPolicy;
 import com.palangwi.soup.domain.news.Summary;
 import com.palangwi.soup.domain.user.User;
@@ -10,7 +9,8 @@ import com.palangwi.soup.dto.news.DailyNewsMailRequestDto;
 import com.palangwi.soup.dto.news.SummaryForMailTemplateDto;
 import com.palangwi.soup.infrastructure.mail.MailViewRenderer;
 import com.palangwi.soup.repository.mail.MailEventRepository;
-import jakarta.transaction.Transactional;
+import java.util.Base64;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.palangwi.soup.domain.mail.MailType.DAILY_NEWS;
 
@@ -30,6 +31,10 @@ public class MailService {
     private final MailAsyncExecutor mailAsyncExecutor;
     private final MailViewRenderer mailViewRenderer;
     private final NewsSelectionPolicy newsSelectionPolicy;
+
+    private static final byte[] TRANSPARENT_PIXEL = Base64.getDecoder().decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+    );
 
     @Transactional
     public void sendDailyNews(DailyNewsMailRequestDto request) {
@@ -69,5 +74,24 @@ public class MailService {
         MailEvent mailEvent = new MailEvent(user.getId(), DAILY_NEWS, now, false);
         mailEventRepository.save(mailEvent);
         return mailEvent;
+    }
+
+    @Transactional
+    public byte[] trackingMail(Long mailId) {
+        Optional<MailEvent> eventOpt = mailEventRepository.findById(mailId);
+
+        if (eventOpt.isPresent()) {
+            MailEvent mailEvent = eventOpt.get();
+            mailEvent.markAsOpen();
+            mailEventRepository.save(mailEvent);
+        } else {
+            log.warn("존재 하지 않는 MailID : {} 에 대한 추적 요청이 발생했습니다.", mailId);
+        }
+
+        return getTransparentPixel();
+    }
+
+    private byte[] getTransparentPixel() {
+        return TRANSPARENT_PIXEL;
     }
 }


### PR DESCRIPTION
## 작업 내용
- 메일 열람 여부 확인을 위한 1x1 PNG tracking pixel 기능 추가
- `/api/v1/mails/traking/open/{mailId}` API 구현
- MailEvent 엔티티에 opened, openedAt 필드 추가
- 메일 HTML 본문에 tracking pixel `<img src=...>` 삽입
- 클라이언트에서 이미지 요청 시 투명 PNG 응답 처리

## 참고 사항
- 기존에는 모든 API 응답을 `ApiResult<T>` 형식으로 감쌌지만,  
  해당 API는 이미지(PNG)를 직접 반환해야 하므로 `ResponseEntity<byte[]>`로 처리했습니다.
- 응답 헤더는 `Content-Type: image/png`로 설정되며, Base64 디코딩된 1x1 PNG 바이트를 반환합니다.
- Gmail 등 일부 메일 클라이언트는 이미지 자동 로드를 제한할 수 있으므로, 수신 확인이 100% 보장되지는 않습니다.