### PR TITLE
[feat] 사용자 키워드 요청 및 구독, 구독 취소 기능 구현

### DIFF
--- a/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
+++ b/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
@@ -35,7 +35,7 @@ public class KeywordController {
         return success(null);
     }
 
-    @Operation(summary = "키워드 등록", description = "새로운 키워드를 등록합니다.")
+    @Operation(summary = "키워드 구독", description = "새로운 키워드를 구독합니다.")
     @ApiResponse(responseCode = "200", description = "등록 성공")
     @PostMapping("/api/v1/keywords")
     public ApiResult<SubscribeKeywordResponseDto> subscribeKeyword(
@@ -51,7 +51,7 @@ public class KeywordController {
         return success(keywordService.unsubscribeKeyword(userDetails.id(), keywordId));
     }
 
-    @PostMapping("/api/v1/keywords-request")
+    @PostMapping("/api/v1/keywords/request")
     public ApiResult<RequestKeywordResponseDto> requestKeywords(
             @AuthenticationPrincipal JwtAuthentication userDetails,
             @Valid @RequestBody RequestKeywordRequestDto requestKeywordRequestDto

--- a/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
+++ b/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
@@ -44,7 +44,7 @@ public class KeywordController {
         return success(keywordService.subscribeKeywords(userDetails.id(), subscribeKeywordRequestDto));
     }
 
-    @DeleteMapping("/api/v1/keywords/{keywordId}")
+    @PostMapping("/api/v1/keywords/{keywordId}")
     public ApiResult<KeywordUnsubscribeResponseDto> unsubscribeKeyword(
             @AuthenticationPrincipal JwtAuthentication userDetails,
             @PathVariable Long keywordId) {

--- a/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
+++ b/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
@@ -2,7 +2,9 @@ package com.palangwi.soup.controller.keyword;
 
 import static com.palangwi.soup.utils.ApiUtils.success;
 
+import com.palangwi.soup.dto.keyword.RequestKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
+import com.palangwi.soup.dto.keyword.response.RequestKeywordResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -38,9 +40,17 @@ public class KeywordController {
     @Operation(summary = "키워드 등록", description = "새로운 키워드를 등록합니다.")
     @ApiResponse(responseCode = "200", description = "등록 성공")
     @PostMapping("/api/v1/keywords")
-    public ApiResult<SubscribeKeywordResponseDto> registerKeyword(
+    public ApiResult<SubscribeKeywordResponseDto> subscribeKeyword(
             @AuthenticationPrincipal JwtAuthentication userDetails,
             @Valid @RequestBody SubscribeKeywordRequestDto subscribeKeywordRequestDto) {
         return success(keywordService.subscribeKeywords(userDetails.id(), subscribeKeywordRequestDto));
+    }
+
+    @PostMapping("/api/v1/keywords-request")
+    public ApiResult<RequestKeywordResponseDto> requestKeywords(
+            @AuthenticationPrincipal JwtAuthentication userDetails,
+            @Valid @RequestBody RequestKeywordRequestDto requestKeywordRequestDto
+    ) {
+        return success(keywordService.requestKeywords(userDetails.id(), requestKeywordRequestDto));
     }
 }

--- a/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
+++ b/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
@@ -4,14 +4,12 @@ import static com.palangwi.soup.utils.ApiUtils.success;
 
 import com.palangwi.soup.dto.keyword.RequestKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
+import com.palangwi.soup.dto.keyword.response.KeywordUnsubscribeResponseDto;
 import com.palangwi.soup.dto.keyword.response.RequestKeywordResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.palangwi.soup.dto.keyword.KeywordResponseDto;
 import com.palangwi.soup.security.JwtAuthentication;
@@ -44,6 +42,13 @@ public class KeywordController {
             @AuthenticationPrincipal JwtAuthentication userDetails,
             @Valid @RequestBody SubscribeKeywordRequestDto subscribeKeywordRequestDto) {
         return success(keywordService.subscribeKeywords(userDetails.id(), subscribeKeywordRequestDto));
+    }
+
+    @DeleteMapping("/api/v1/keywords/{keywordId}")
+    public ApiResult<KeywordUnsubscribeResponseDto> unsubscribeKeyword(
+            @AuthenticationPrincipal JwtAuthentication userDetails,
+            @PathVariable Long keywordId) {
+        return success(keywordService.unsubscribeKeyword(userDetails.id(), keywordId));
     }
 
     @PostMapping("/api/v1/keywords-request")

--- a/src/main/java/com/palangwi/soup/domain/userkeyword/UserKeywords.java
+++ b/src/main/java/com/palangwi/soup/domain/userkeyword/UserKeywords.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
 import lombok.Getter;
 
 @Getter
@@ -30,5 +32,11 @@ public class UserKeywords {
     public boolean isAlreadySubscribed(Keyword keyword) {
         return userKeywordList.stream()
                 .anyMatch(uk -> uk.getKeyword().equals(keyword) && uk.isSubscribed());
+    }
+
+    public Optional<UserKeyword> findByKeyword(Keyword keyword) {
+        return userKeywordList.stream()
+                .filter(uk -> uk.getKeyword().equals(keyword))
+                .findFirst();
     }
 }

--- a/src/main/java/com/palangwi/soup/dto/keyword/RequestKeywordRequestDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/RequestKeywordRequestDto.java
@@ -1,0 +1,4 @@
+package com.palangwi.soup.dto.keyword;
+
+public record RequestKeywordRequestDto(Long userId, String keyword) {
+}

--- a/src/main/java/com/palangwi/soup/dto/keyword/response/KeywordUnsubscribeResponseDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/response/KeywordUnsubscribeResponseDto.java
@@ -1,0 +1,9 @@
+package com.palangwi.soup.dto.keyword.response;
+
+import com.palangwi.soup.domain.userkeyword.UserKeyword;
+
+public record KeywordUnsubscribeResponseDto(Long userId, String keyword) {
+    public static KeywordUnsubscribeResponseDto of(UserKeyword userKeyword) {
+        return new KeywordUnsubscribeResponseDto(userKeyword.getUser().getId(), userKeyword.getKeyword().getName());
+    }
+}

--- a/src/main/java/com/palangwi/soup/dto/keyword/response/RequestKeywordResponseDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/response/RequestKeywordResponseDto.java
@@ -1,0 +1,13 @@
+package com.palangwi.soup.dto.keyword.response;
+
+import com.palangwi.soup.domain.keyword.Keyword;
+import com.palangwi.soup.domain.user.User;
+
+public record RequestKeywordResponseDto(Long userId, String keyword) {
+    public static RequestKeywordResponseDto of(User user, Keyword keyword) {
+        return new RequestKeywordResponseDto(
+                user.getId(),
+                keyword.getName()
+        );
+    }
+}

--- a/src/main/java/com/palangwi/soup/exception/keyword/KeywordExceptionMessage.java
+++ b/src/main/java/com/palangwi/soup/exception/keyword/KeywordExceptionMessage.java
@@ -10,7 +10,8 @@ public enum KeywordExceptionMessage {
     ALREADY_SUBSCRIBED_KEYWORD("이미 등록된 키워드입니다.", HttpStatus.BAD_REQUEST),
     ALREADY_REJECTED_KEYWORD("관리자에 의해 등록이 제한된 키워드입니다.", HttpStatus.BAD_REQUEST),
     KEYWORD_INVALID_STATUS_EXCEPTION("키워드의 상태가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
-    KEYWORD_ALREADY_REQUESTED("이미 등록 요청한 키워드입니다.", HttpStatus.BAD_REQUEST),;
+    KEYWORD_ALREADY_REQUESTED("이미 등록 요청한 키워드입니다.", HttpStatus.BAD_REQUEST),
+    KEYWORD_NOT_EXIST("존재하지 않는 키워드입니다.", HttpStatus.BAD_REQUEST),;
 
 
     private final String message;

--- a/src/main/java/com/palangwi/soup/exception/keyword/KeywordNotExistException.java
+++ b/src/main/java/com/palangwi/soup/exception/keyword/KeywordNotExistException.java
@@ -1,0 +1,24 @@
+package com.palangwi.soup.exception.keyword;
+
+import com.palangwi.soup.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+public class KeywordNotExistException extends BaseCustomException {
+  private final List<String> notExistsKeywords;
+
+  public KeywordNotExistException(List<String> notExistsKeywords) {
+    this.notExistsKeywords = notExistsKeywords;
+  }
+
+  @Override
+  public String getMessage() {
+    return KeywordExceptionMessage.KEYWORD_NOT_EXIST.getMessage()  + ": "
+            + String.join(", ", notExistsKeywords);
+  }
+
+  public HttpStatus getStatus() {
+    return KeywordExceptionMessage.KEYWORD_NOT_EXIST.getStatus();
+  }
+}

--- a/src/main/java/com/palangwi/soup/repository/keyword/KeywordRepository.java
+++ b/src/main/java/com/palangwi/soup/repository/keyword/KeywordRepository.java
@@ -12,6 +12,8 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
     
     boolean existsByName(String name);
 
+    boolean existsByNameAndStatus(String name, Status status);
+
     Optional<Keyword> findByName(String name);
 
     List<Keyword> findAllByNameIn(List<String> names);

--- a/src/main/java/com/palangwi/soup/repository/userkeyword/UserKeywordRepository.java
+++ b/src/main/java/com/palangwi/soup/repository/userkeyword/UserKeywordRepository.java
@@ -2,8 +2,11 @@ package com.palangwi.soup.repository.userkeyword;
 
 import com.palangwi.soup.domain.userkeyword.UserKeyword;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,4 +14,7 @@ public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> 
 
     @Query("SELECT uk FROM UserKeyword uk JOIN FETCH uk.user JOIN FETCH uk.keyword WHERE uk.subscribed = true")
     List<UserKeyword> findAllSubscribedUserKeywords();
+
+    @Query("SELECT uk FROM UserKeyword uk WHERE uk.user.id = :userId AND uk.keyword.id = :keywordId AND uk.subscribed = true")
+    Optional<UserKeyword> findSubscribedByUserIdAndKeywordId(@Param("userId") Long userId, @Param("keywordId") Long keywordId);
 }

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordService.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordService.java
@@ -1,8 +1,11 @@
 package com.palangwi.soup.service.keyword;
 
 import com.palangwi.soup.dto.keyword.KeywordResponseDto;
+import com.palangwi.soup.dto.keyword.RequestKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
+import com.palangwi.soup.dto.keyword.response.RequestKeywordResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
+import jakarta.validation.Valid;
 
 public interface KeywordService {
 
@@ -15,4 +18,6 @@ public interface KeywordService {
     SubscribeKeywordResponseDto subscribeKeywords(Long userId, SubscribeKeywordRequestDto subscribeKeywordRequestDto);
 
     void deleteKeyword(Long id);
+
+    RequestKeywordResponseDto requestKeywords(Long userId, RequestKeywordRequestDto requestKeywordRequestDto);
 }

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordService.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordService.java
@@ -3,6 +3,7 @@ package com.palangwi.soup.service.keyword;
 import com.palangwi.soup.dto.keyword.KeywordResponseDto;
 import com.palangwi.soup.dto.keyword.RequestKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
+import com.palangwi.soup.dto.keyword.response.KeywordUnsubscribeResponseDto;
 import com.palangwi.soup.dto.keyword.response.RequestKeywordResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
 import jakarta.validation.Valid;
@@ -20,4 +21,6 @@ public interface KeywordService {
     void deleteKeyword(Long id);
 
     RequestKeywordResponseDto requestKeywords(Long userId, RequestKeywordRequestDto requestKeywordRequestDto);
+
+    KeywordUnsubscribeResponseDto unsubscribeKeyword(Long id, Long keywordId);
 }

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
@@ -3,17 +3,15 @@ package com.palangwi.soup.service.keyword;
 import static com.palangwi.soup.utils.KeywordNormalizer.*;
 
 import com.palangwi.soup.domain.keyword.PendingKeywordRequest;
+import com.palangwi.soup.domain.keyword.Status;
+import com.palangwi.soup.dto.keyword.RequestKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
+import com.palangwi.soup.dto.keyword.response.RequestKeywordResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
-import com.palangwi.soup.exception.keyword.AlreadyRejectedKeywordException;
-import com.palangwi.soup.exception.keyword.KeywordAlreadyRequestedException;
+import com.palangwi.soup.exception.keyword.*;
 import com.palangwi.soup.repository.keyword.PendingKeywordRequestRepository;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -24,7 +22,6 @@ import com.palangwi.soup.domain.keyword.Source;
 import com.palangwi.soup.domain.user.User;
 import com.palangwi.soup.domain.userkeyword.UserKeyword;
 import com.palangwi.soup.dto.keyword.KeywordResponseDto;
-import com.palangwi.soup.exception.keyword.AlreadySubscribedKeywordException;
 import com.palangwi.soup.exception.user.UserNotFoundException;
 import com.palangwi.soup.repository.keyword.KeywordRepository;
 import com.palangwi.soup.repository.userkeyword.UserKeywordRepository;
@@ -58,12 +55,37 @@ public class KeywordServiceImpl implements KeywordService {
     }
 
     @Transactional
+    public RequestKeywordResponseDto requestKeywords(Long userId, RequestKeywordRequestDto requestKeywordRequestDto) {
+        User user = findUserById(userId);
+
+        String requestedKeyword = requestKeywordRequestDto.keyword();
+        String normalizedKeyword = normalize(requestedKeyword);
+
+        Keyword keyword = findOrCreateKeyword(requestedKeyword, normalizedKeyword, user);
+
+        initPendingKeywordRequest(user, keyword);
+        return RequestKeywordResponseDto.of(user, keyword);
+    }
+
+    private Keyword findOrCreateKeyword(String requestedKeyword, String normalizedKeyword, User user) {
+        if (keywordRepository.existsByNameAndStatus(requestedKeyword, Status.ACTIVE)) {
+            throw new KeywordAlreadyRequestedException();
+        }
+
+        return keywordRepository.findByNameAndStatus(requestedKeyword, Status.PENDING)
+                .orElseGet(() -> {
+                    Keyword newKeyword = Keyword.of(requestedKeyword, normalizedKeyword, Source.USER_REQUEST, user);
+                    return keywordRepository.save(newKeyword);
+                });
+    }
+
+    @Transactional
     public SubscribeKeywordResponseDto subscribeKeywords(Long userId,
                                                        SubscribeKeywordRequestDto subscribeKeywordRequestDto) {
         List<String> keywords = subscribeKeywordRequestDto.subscribeKeywords();
 
         User user = findUserById(userId);
-        List<Keyword> allKeywords = getOrCreateKeywords(keywords, user);
+        List<Keyword> allKeywords = validateKeywords(user, keywords);
 
         List<UserKeyword> userKeywords = createUserKeywordsIfNotSubscribed(user, allKeywords);
         userKeywordRepository.saveAll(userKeywords);
@@ -74,66 +96,40 @@ public class KeywordServiceImpl implements KeywordService {
                         .toList());
     }
 
-    private List<Keyword> getOrCreateKeywords(List<String> keywords, User user) {
+    private List<Keyword> validateKeywords(User user, List<String> keywords) {
         List<Keyword> existingKeywords = keywordRepository.findAllByNameIn(keywords);
 
-        Set<String> existingKeywordNames = existingKeywords.stream()
-                .map(Keyword::getName)
-                .collect(Collectors.toSet());
+        Map<String, Keyword> keywordMap = existingKeywords.stream()
+                .collect(Collectors.toMap(Keyword::getName, k -> k));
 
-        List<Keyword> result = new ArrayList<>(existingKeywords);
+        List<String> notFoundKeywords = keywords.stream()
+                .filter(name -> !keywordMap.containsKey(name))
+                .toList();
 
-        for (String name : keywords) {
-            if (existingKeywordNames.contains(name)) continue;
-
-            Keyword keyword = handleNonExistingKeyword(name, user);
-            result.add(keyword);
-        }
-        return result;
-    }
-
-    private Keyword handleNonExistingKeyword(String name, User user) {
-        Optional<Keyword> keywordOpt = keywordRepository.findByName(name);
-
-        if (keywordOpt.isPresent()) {
-            Keyword keyword = keywordOpt.get();
-
-            switch (keyword.getStatus()) {
-                case REJECTED -> {
-                    if (keyword.getRejectedAt() != null &&
-                    keyword.getRejectedAt().isAfter(LocalDateTime.now().minusMonths(1))) {
-                        throw new AlreadyRejectedKeywordException();
-                    }
-
-                    if (pendingKeywordRequestRepository.existsByUserAndKeyword(user, keyword)) {
-                        throw new KeywordAlreadyRequestedException();
-                    }
-                    initPendingKeywordRequest(user, keyword);
-                    return keyword;
-                }
-
-                case PENDING -> {
-                    if (pendingKeywordRequestRepository.existsByUserAndKeyword(user, keyword)) {
-                        throw new KeywordAlreadyRequestedException();
-                    }
-                    initPendingKeywordRequest(user, keyword);
-                    return keyword;
-                }
-            };
+        if (!notFoundKeywords.isEmpty()) {
+            throw new KeywordNotExistException(notFoundKeywords);
         }
 
-        return createNewKeyword(name, user);
+        List<String> alreadySubscribed = keywords.stream()
+                .filter(name -> user.getUserKeywords().isAlreadySubscribed(keywordMap.get(name)))
+                .toList();
+
+        if (!alreadySubscribed.isEmpty()) {
+            throw new AlreadySubscribedKeywordException(alreadySubscribed);
+        }
+
+        return keywords.stream()
+                .map(keywordMap::get)
+                .toList();
     }
 
     private void initPendingKeywordRequest(User user, Keyword keyword) {
+        if (pendingKeywordRequestRepository.existsByUserAndKeyword(user, keyword)) {
+            throw new KeywordAlreadyRequestedException();
+        }
+
         PendingKeywordRequest request = PendingKeywordRequest.of(user, keyword);
         pendingKeywordRequestRepository.save(request);
-    }
-
-    private Keyword createNewKeyword(String name, User user) {
-        String normalizedName = normalize(name);
-        Keyword keyword = Keyword.of(name.toLowerCase(), normalizedName, Source.USER_REQUEST, user);
-        return keywordRepository.save(keyword);
     }
 
     private User findUserById(Long userId) {
@@ -142,18 +138,9 @@ public class KeywordServiceImpl implements KeywordService {
     }
 
     private List<UserKeyword> createUserKeywordsIfNotSubscribed(User user, List<Keyword> keywords) {
-        List<String> alreadySubscribedNames = new ArrayList<>();
         List<UserKeyword> userKeywords = new ArrayList<>();
         for (Keyword keyword : keywords) {
-            boolean alreadySubscribed = user.getUserKeywords().isAlreadySubscribed(keyword);
-            if (alreadySubscribed) {
-                alreadySubscribedNames.add(keyword.getName());
-            } else {
-                userKeywords.add(UserKeyword.create(user, keyword));
-            }
-        }
-        if (!alreadySubscribedNames.isEmpty()) {
-            throw new AlreadySubscribedKeywordException(alreadySubscribedNames);
+            userKeywords.add(UserKeyword.create(user, keyword));
         }
         return userKeywords;
     }

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
@@ -93,67 +93,18 @@ public class KeywordServiceImpl implements KeywordService {
 
     @Transactional
     public SubscribeKeywordResponseDto subscribeKeywords(Long userId,
-                                                       SubscribeKeywordRequestDto subscribeKeywordRequestDto) {
+                                                         SubscribeKeywordRequestDto subscribeKeywordRequestDto) {
         User user = findUserById(userId);
-        List<String> keywords = subscribeKeywordRequestDto.subscribeKeywords();
+        List<String> keywordNames = subscribeKeywordRequestDto.subscribeKeywords();
 
-        List<UserKeyword> toSave = new ArrayList<>();
-        List<Keyword> validKeywords = validateKeywords(user, keywords, toSave);
-
-        List<UserKeyword> userKeywords = createUserKeywords(user, validKeywords);
-        toSave.addAll(userKeywords);
-
-        userKeywordRepository.saveAll(toSave);
+        List<UserKeyword> userKeywords = createUserKeywords(user, keywordNames);
+        userKeywordRepository.saveAll(userKeywords);
 
         return SubscribeKeywordResponseDto.of(
-                validKeywords.stream()
-                        .map(Keyword::getName)
-                        .toList());
-    }
-
-    private List<Keyword> validateKeywords(User user, List<String> keywords, List<UserKeyword> toSave) {
-        List<Keyword> existingKeywords = keywordRepository.findAllByNameIn(keywords);
-
-        Map<String, Keyword> keywordMap = existingKeywords.stream()
-                .collect(Collectors.toMap(Keyword::getName, k -> k));
-
-        List<String> notFoundKeywords = keywords.stream()
-                .filter(name -> !keywordMap.containsKey(name))
-                .toList();
-
-        if (!notFoundKeywords.isEmpty()) {
-            log.warn("{} 사용자가 요청한 다음 키워드들을 찾을 수 없습니다: {}", user.getId(), notFoundKeywords);
-            throw new KeywordNotExistException(notFoundKeywords);
-        }
-
-        List<String> alreadySubscribed = new ArrayList<>();
-
-        handleExistingUserKeywords(user, keywords, toSave, keywordMap, alreadySubscribed);
-
-        if (!alreadySubscribed.isEmpty()) {
-            throw new AlreadySubscribedKeywordException(alreadySubscribed);
-        }
-
-        return keywords.stream()
-                .map(keywordMap::get)
-                .toList();
-    }
-
-    private static void handleExistingUserKeywords(User user, List<String> keywords, List<UserKeyword> toSave, Map<String, Keyword> keywordMap, List<String> alreadySubscribed) {
-        for (String name : keywords) {
-            Keyword keyword = keywordMap.get(name);
-
-            user.getUserKeywords().findByKeyword(keyword).ifPresent(
-                    userKeyword -> {
-                        if (userKeyword.isSubscribed()) {
-                            alreadySubscribed.add(name);
-                        } else {
-                            userKeyword.subscribe();
-                            toSave.add(userKeyword);
-                        }
-                    }
-            );
-        }
+                userKeywords.stream()
+                        .map(userKeyword -> userKeyword.getKeyword().getName())
+                        .toList()
+        );
     }
 
     private void initPendingKeywordRequest(User user, Keyword keyword) {
@@ -170,11 +121,52 @@ public class KeywordServiceImpl implements KeywordService {
                 .orElseThrow(UserNotFoundException::new);
     }
 
-    private List<UserKeyword> createUserKeywords(User user, List<Keyword> keywords) {
-        List<UserKeyword> userKeywords = new ArrayList<>();
-        for (Keyword keyword : keywords) {
-            userKeywords.add(UserKeyword.create(user, keyword));
+    private List<UserKeyword> createUserKeywords(User user, List<String> keywordNames) {
+        Map<String, Keyword> keywordMap = validateKeywordNames(user, keywordNames);
+        return filterAndBuildUserKeywords(user, keywordNames, keywordMap);
+    }
+
+    private Map<String, Keyword> validateKeywordNames(User user, List<String> keywordNames) {
+        List<Keyword> existingKeywords = keywordRepository.findAllByNameIn(keywordNames);
+        Map<String, Keyword> keywordMap = existingKeywords.stream()
+                .collect(Collectors.toMap(Keyword::getName, k -> k));
+
+        List<String> notFound = keywordNames.stream()
+                .filter(name -> !keywordMap.containsKey(name))
+                .toList();
+
+        if (!notFound.isEmpty()) {
+            log.warn("{} 사용자가 요청한 다음 키워드들을 찾을 수 없습니다: {}", user.getId(), notFound);
+            throw new KeywordNotExistException(notFound);
         }
-        return userKeywords;
+
+        return keywordMap;
+    }
+
+    private List<UserKeyword> filterAndBuildUserKeywords(User user, List<String> keywordNames, Map<String, Keyword> keywordMap) {
+        List<UserKeyword> result = new ArrayList<>();
+        List<String> alreadySubscribed = new ArrayList<>();
+
+        for (String name : keywordNames) {
+            Keyword keyword = keywordMap.get(name);
+
+            user.getUserKeywords().findByKeyword(keyword).ifPresentOrElse(
+                    userKeyword -> {
+                        if (userKeyword.isSubscribed()) {
+                            alreadySubscribed.add(name);
+                        } else {
+                            userKeyword.subscribe();
+                            result.add(userKeyword);
+                        }
+                    },
+                    () -> result.add(UserKeyword.create(user, keyword))
+            );
+        }
+
+        if (!alreadySubscribed.isEmpty()) {
+            throw new AlreadySubscribedKeywordException(alreadySubscribed);
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
@@ -6,6 +6,7 @@ import com.palangwi.soup.domain.keyword.PendingKeywordRequest;
 import com.palangwi.soup.domain.keyword.Status;
 import com.palangwi.soup.dto.keyword.RequestKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
+import com.palangwi.soup.dto.keyword.response.KeywordUnsubscribeResponseDto;
 import com.palangwi.soup.dto.keyword.response.RequestKeywordResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
 import com.palangwi.soup.exception.keyword.*;
@@ -66,6 +67,14 @@ public class KeywordServiceImpl implements KeywordService {
         return RequestKeywordResponseDto.of(user, keyword);
     }
 
+    @Transactional
+    public KeywordUnsubscribeResponseDto unsubscribeKeyword(Long userId, Long keywordId) {
+        UserKeyword userKeyword = userKeywordRepository.findSubscribedByUserIdAndKeywordId(userId, keywordId)
+                .orElseThrow(NotSubscribedException::new);
+        userKeyword.unsubscribe();
+        return KeywordUnsubscribeResponseDto.of(userKeyword);
+    }
+
     private Keyword findOrCreateKeyword(String requestedKeyword, User user) {
         String normalizedKeyword = normalize(requestedKeyword);
 
@@ -83,21 +92,24 @@ public class KeywordServiceImpl implements KeywordService {
     @Transactional
     public SubscribeKeywordResponseDto subscribeKeywords(Long userId,
                                                        SubscribeKeywordRequestDto subscribeKeywordRequestDto) {
+        User user = findUserById(userId);
         List<String> keywords = subscribeKeywordRequestDto.subscribeKeywords();
 
-        User user = findUserById(userId);
-        List<Keyword> allKeywords = validateKeywords(user, keywords);
+        List<UserKeyword> toSave = new ArrayList<>();
+        List<Keyword> validKeywords = validateKeywords(user, keywords, toSave);
 
-        List<UserKeyword> userKeywords = createUserKeywords(user, allKeywords);
-        userKeywordRepository.saveAll(userKeywords);
+        List<UserKeyword> userKeywords = createUserKeywords(user, validKeywords);
+        toSave.addAll(userKeywords);
+
+        userKeywordRepository.saveAll(toSave);
 
         return SubscribeKeywordResponseDto.of(
-                allKeywords.stream()
+                validKeywords.stream()
                         .map(Keyword::getName)
                         .toList());
     }
 
-    private List<Keyword> validateKeywords(User user, List<String> keywords) {
+    private List<Keyword> validateKeywords(User user, List<String> keywords, List<UserKeyword> toSave) {
         List<Keyword> existingKeywords = keywordRepository.findAllByNameIn(keywords);
 
         Map<String, Keyword> keywordMap = existingKeywords.stream()
@@ -111,9 +123,9 @@ public class KeywordServiceImpl implements KeywordService {
             throw new KeywordNotExistException(notFoundKeywords);
         }
 
-        List<String> alreadySubscribed = keywords.stream()
-                .filter(name -> user.getUserKeywords().isAlreadySubscribed(keywordMap.get(name)))
-                .toList();
+        List<String> alreadySubscribed = new ArrayList<>();
+
+        handleExistingUserKeywords(user, keywords, toSave, keywordMap, alreadySubscribed);
 
         if (!alreadySubscribed.isEmpty()) {
             throw new AlreadySubscribedKeywordException(alreadySubscribed);
@@ -122,6 +134,23 @@ public class KeywordServiceImpl implements KeywordService {
         return keywords.stream()
                 .map(keywordMap::get)
                 .toList();
+    }
+
+    private static void handleExistingUserKeywords(User user, List<String> keywords, List<UserKeyword> toSave, Map<String, Keyword> keywordMap, List<String> alreadySubscribed) {
+        for (String name : keywords) {
+            Keyword keyword = keywordMap.get(name);
+
+            user.getUserKeywords().findByKeyword(keyword).ifPresent(
+                    userKeyword -> {
+                        if (userKeyword.isSubscribed()) {
+                            alreadySubscribed.add(name);
+                        } else {
+                            userKeyword.subscribe();
+                            toSave.add(userKeyword);
+                        }
+                    }
+            );
+        }
     }
 
     private void initPendingKeywordRequest(User user, Keyword keyword) {

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
@@ -15,6 +15,7 @@ import com.palangwi.soup.repository.keyword.PendingKeywordRequestRepository;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +32,7 @@ import com.palangwi.soup.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class KeywordServiceImpl implements KeywordService {
 
@@ -120,6 +122,7 @@ public class KeywordServiceImpl implements KeywordService {
                 .toList();
 
         if (!notFoundKeywords.isEmpty()) {
+            log.warn("{} 사용자가 요청한 다음 키워드들을 찾을 수 없습니다: {}", user.getId(), notFoundKeywords);
             throw new KeywordNotExistException(notFoundKeywords);
         }
 

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
@@ -59,15 +59,16 @@ public class KeywordServiceImpl implements KeywordService {
         User user = findUserById(userId);
 
         String requestedKeyword = requestKeywordRequestDto.keyword();
-        String normalizedKeyword = normalize(requestedKeyword);
 
-        Keyword keyword = findOrCreateKeyword(requestedKeyword, normalizedKeyword, user);
+        Keyword keyword = findOrCreateKeyword(requestedKeyword, user);
 
         initPendingKeywordRequest(user, keyword);
         return RequestKeywordResponseDto.of(user, keyword);
     }
 
-    private Keyword findOrCreateKeyword(String requestedKeyword, String normalizedKeyword, User user) {
+    private Keyword findOrCreateKeyword(String requestedKeyword, User user) {
+        String normalizedKeyword = normalize(requestedKeyword);
+
         if (keywordRepository.existsByNameAndStatus(requestedKeyword, Status.ACTIVE)) {
             throw new KeywordAlreadyRequestedException();
         }
@@ -87,7 +88,7 @@ public class KeywordServiceImpl implements KeywordService {
         User user = findUserById(userId);
         List<Keyword> allKeywords = validateKeywords(user, keywords);
 
-        List<UserKeyword> userKeywords = createUserKeywordsIfNotSubscribed(user, allKeywords);
+        List<UserKeyword> userKeywords = createUserKeywords(user, allKeywords);
         userKeywordRepository.saveAll(userKeywords);
 
         return SubscribeKeywordResponseDto.of(
@@ -137,7 +138,7 @@ public class KeywordServiceImpl implements KeywordService {
                 .orElseThrow(UserNotFoundException::new);
     }
 
-    private List<UserKeyword> createUserKeywordsIfNotSubscribed(User user, List<Keyword> keywords) {
+    private List<UserKeyword> createUserKeywords(User user, List<Keyword> keywords) {
         List<UserKeyword> userKeywords = new ArrayList<>();
         for (Keyword keyword : keywords) {
             userKeywords.add(UserKeyword.create(user, keyword));

--- a/src/test/java/com/palangwi/soup/service/keyword/KeywordServiceTest.java
+++ b/src/test/java/com/palangwi/soup/service/keyword/KeywordServiceTest.java
@@ -73,7 +73,12 @@ class KeywordServiceTest extends IntegrationTestSupport {
     void registerKeyword_정상등록() {
         // given
         User user = createUser("테스트 닉네임");
+        Keyword keyword1 = Keyword.of("키워드1", "키워드1", Source.USER_REQUEST, user);
+        Keyword keyword2 = Keyword.of("키워드2", "키워드2", Source.USER_REQUEST, user);
+        keywordRepository.saveAll(Arrays.asList(keyword1, keyword2));
+
         List<String> keywords = Arrays.asList("키워드1", "키워드2");
+
         SubscribeKeywordRequestDto requestDto = new SubscribeKeywordRequestDto(keywords);
 
         // when


### PR DESCRIPTION
## 작업 내용
- 사용자 키워드 등록 요청 API 개발 (`/keywords/request`)
  - 사용자 요청 기반으로 `Keyword` 및 `PendingKeywordRequest` 생성 처리
- `UserKeyword` 생성 메서드 리팩토링
  - 정적 팩토리 메서드 `create(user, keyword)` 중심으로 통일
- 키워드 정규화 로직 위치 수정
  - 서비스 레이어에서 정규화하도록 책임 이동
- 키워드 구독 취소 (`unsubscribe`) 및 재구독 (`resubscribe`) 기능 구현
  - 기존 구독 내역 상태 변경으로 처리 (DB 엔티티 재활용)

## 참고 사항
- 중복 구독 요청 시 `AlreadySubscribedKeywordException` 발생
- 재구독 시 새로운 엔티티 생성 없이 기존 엔티티의 상태만 변경