### PR TITLE
[feat] 메일 테스트 및 스케줄 확인

### DIFF
--- a/src/main/java/com/palangwi/soup/controller/admin/email/EmailController.java
+++ b/src/main/java/com/palangwi/soup/controller/admin/email/EmailController.java
@@ -2,6 +2,7 @@ package com.palangwi.soup.controller.admin.email;
 
 import static com.palangwi.soup.utils.ApiUtils.success;
 
+import com.palangwi.soup.dto.admin.email.EmailScheduleResponseDto;
 import com.palangwi.soup.dto.admin.email.EmailTestResponseDto;
 import com.palangwi.soup.security.JwtAuthentication;
 import com.palangwi.soup.service.mail.MailService;
@@ -21,8 +22,13 @@ public class EmailController {
 
     @GetMapping("/test")
     public ApiResult<EmailTestResponseDto> emailTest(
-            @AuthenticationPrincipal JwtAuthentication userInfo
-    ) {
+            @AuthenticationPrincipal JwtAuthentication userInfo) {
         return success(mailService.testMail(userInfo.id()));
+    }
+
+    @GetMapping("/schedule")
+    public ApiResult<EmailScheduleResponseDto> emailSchedule(
+            @AuthenticationPrincipal JwtAuthentication userInfo) {
+        return success(mailService.getMailSchedule());
     }
 }

--- a/src/main/java/com/palangwi/soup/controller/admin/email/EmailController.java
+++ b/src/main/java/com/palangwi/soup/controller/admin/email/EmailController.java
@@ -21,13 +21,13 @@ public class EmailController {
     private final MailService mailService;
 
     @GetMapping("/test")
-    public ApiResult<EmailTestResponseDto> emailTest(
+    public ApiResult<EmailTestResponseDto> testEmail(
             @AuthenticationPrincipal JwtAuthentication userInfo) {
-        return success(mailService.testMail(userInfo.id()));
+        return success(mailService.testEmail(userInfo.id()));
     }
 
     @GetMapping("/schedule")
-    public ApiResult<EmailScheduleResponseDto> emailSchedule(
+    public ApiResult<EmailScheduleResponseDto> getEmailSchedule(
             @AuthenticationPrincipal JwtAuthentication userInfo) {
         return success(mailService.getMailSchedule());
     }

--- a/src/main/java/com/palangwi/soup/controller/admin/email/EmailController.java
+++ b/src/main/java/com/palangwi/soup/controller/admin/email/EmailController.java
@@ -1,0 +1,28 @@
+package com.palangwi.soup.controller.admin.email;
+
+import static com.palangwi.soup.utils.ApiUtils.success;
+
+import com.palangwi.soup.dto.admin.email.EmailTestResponseDto;
+import com.palangwi.soup.security.JwtAuthentication;
+import com.palangwi.soup.service.mail.MailService;
+import com.palangwi.soup.utils.ApiUtils.ApiResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/email")
+public class EmailController {
+
+    private final MailService mailService;
+
+    @GetMapping("/test")
+    public ApiResult<EmailTestResponseDto> emailTest(
+            @AuthenticationPrincipal JwtAuthentication userInfo
+    ) {
+        return success(mailService.testMail(userInfo.id()));
+    }
+}

--- a/src/main/java/com/palangwi/soup/domain/mail/MailType.java
+++ b/src/main/java/com/palangwi/soup/domain/mail/MailType.java
@@ -2,5 +2,6 @@ package com.palangwi.soup.domain.mail;
 
 public enum MailType {
     DAILY_NEWS, // 뉴스
-    NOTIFICATION // 공지
+    NOTIFICATION, // 공지
+    TEST // 테스트
 }

--- a/src/main/java/com/palangwi/soup/dto/admin/email/EmailScheduleResponseDto.java
+++ b/src/main/java/com/palangwi/soup/dto/admin/email/EmailScheduleResponseDto.java
@@ -1,0 +1,7 @@
+package com.palangwi.soup.dto.admin.email;
+
+public record EmailScheduleResponseDto(String lastStatus, String lastExecutionTime, String nextExecutionTime, int activeTasks) {
+    public static EmailScheduleResponseDto of(String lastStatus, String lastExecutionTime, String nextExecutionTime, int activeTasks) {
+        return new EmailScheduleResponseDto(lastStatus, lastExecutionTime, nextExecutionTime, activeTasks);
+    }
+}

--- a/src/main/java/com/palangwi/soup/dto/admin/email/EmailTestResponseDto.java
+++ b/src/main/java/com/palangwi/soup/dto/admin/email/EmailTestResponseDto.java
@@ -1,0 +1,9 @@
+package com.palangwi.soup.dto.admin.email;
+
+import com.palangwi.soup.domain.user.User;
+
+public record EmailTestResponseDto(String email) {
+    public static EmailTestResponseDto of(User user) {
+        return new EmailTestResponseDto(user.getEmail());
+    }
+}

--- a/src/main/java/com/palangwi/soup/dto/admin/email/EmailTestResponseDto.java
+++ b/src/main/java/com/palangwi/soup/dto/admin/email/EmailTestResponseDto.java
@@ -1,9 +1,10 @@
 package com.palangwi.soup.dto.admin.email;
 
 import com.palangwi.soup.domain.user.User;
+import java.time.LocalDateTime;
 
-public record EmailTestResponseDto(String email) {
-    public static EmailTestResponseDto of(User user) {
-        return new EmailTestResponseDto(user.getEmail());
+public record EmailTestResponseDto(String email, LocalDateTime sentAt) {
+    public static EmailTestResponseDto of(User user, LocalDateTime sentAt) {
+        return new EmailTestResponseDto(user.getEmail(), sentAt);
     }
 }

--- a/src/main/java/com/palangwi/soup/dto/mail/MailMessage.java
+++ b/src/main/java/com/palangwi/soup/dto/mail/MailMessage.java
@@ -1,6 +1,10 @@
 package com.palangwi.soup.dto.mail;
 
 import com.palangwi.soup.domain.mail.MailType;
+import com.palangwi.soup.domain.user.User;
 
 public record MailMessage(Long userId, String to, String subject, String text, MailType type, Long mailEventId) {
+    public static MailMessage of(User user, String subject, String text, MailType type, Long mailEventId) {
+        return new MailMessage(user.getId(), user.getEmail(), subject, text, type, mailEventId);
+    }
 }

--- a/src/main/java/com/palangwi/soup/exception/mail/MailExceptionMessage.java
+++ b/src/main/java/com/palangwi/soup/exception/mail/MailExceptionMessage.java
@@ -1,0 +1,17 @@
+package com.palangwi.soup.exception.mail;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum MailExceptionMessage {
+    MAIL_EVENT_NOT_FOUND("메일 기록이 존재하지 않습니다.", HttpStatus.NOT_FOUND),;
+
+    private final String message;
+    private final HttpStatus status;
+
+    MailExceptionMessage(String message, HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/palangwi/soup/exception/mail/MailNotFoundException.java
+++ b/src/main/java/com/palangwi/soup/exception/mail/MailNotFoundException.java
@@ -1,0 +1,15 @@
+package com.palangwi.soup.exception.mail;
+
+import com.palangwi.soup.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class MailNotFoundException extends BaseCustomException {
+    @Override
+    public String getMessage() {
+        return MailExceptionMessage.MAIL_EVENT_NOT_FOUND.getMessage();
+    }
+
+    public HttpStatus getStatus() {
+        return MailExceptionMessage.MAIL_EVENT_NOT_FOUND.getStatus();
+    }
+}

--- a/src/main/java/com/palangwi/soup/infrastructure/mail/MailViewRenderer.java
+++ b/src/main/java/com/palangwi/soup/infrastructure/mail/MailViewRenderer.java
@@ -4,6 +4,7 @@ import com.palangwi.soup.domain.news.Summary;
 import com.palangwi.soup.domain.user.User;
 import com.palangwi.soup.dto.news.SummaryForMailTemplateDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
@@ -16,6 +17,9 @@ public class MailViewRenderer {
 
     private final TemplateEngine templateEngine;
 
+    @Value("${server.domain}")
+    private String serverDomain;
+
     /**
      * Todo : 요약 정보 넣기
      */
@@ -23,7 +27,7 @@ public class MailViewRenderer {
         Context context = new Context();
         context.setVariable("name", username);
         context.setVariable("summaries", summaries);
-        context.setVariable("trackingUrl", "https://my-homepage/read?eventId=" + mailEventId);
+        context.setVariable("trackingUrl", serverDomain + "/mails/traking/open/" + mailEventId);
         // resources/templates/mail/daily-news.html 파일에 적용
         return templateEngine.process("mail/daily-news", context);
     }

--- a/src/main/java/com/palangwi/soup/repository/mail/MailEventRepository.java
+++ b/src/main/java/com/palangwi/soup/repository/mail/MailEventRepository.java
@@ -1,9 +1,12 @@
 package com.palangwi.soup.repository.mail;
 
 import com.palangwi.soup.domain.mail.MailEvent;
+import com.palangwi.soup.domain.mail.MailType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MailEventRepository extends JpaRepository<MailEvent, Long> {
+    Optional<MailEvent> findTopByTypeOrderByCreatedDateDesc(MailType type);
 }

--- a/src/main/java/com/palangwi/soup/repository/userkeyword/UserKeywordRepository.java
+++ b/src/main/java/com/palangwi/soup/repository/userkeyword/UserKeywordRepository.java
@@ -11,4 +11,7 @@ public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> 
 
     @Query("SELECT uk FROM UserKeyword uk JOIN FETCH uk.user JOIN FETCH uk.keyword WHERE uk.subscribed = true")
     List<UserKeyword> findAllSubscribedUserKeywords();
+
+    @Query("SELECT DISTINCT uk.user FROM UserKeyword uk WHERE uk.subscribed = true")
+    List<UserKeyword> findAllSubscribedUserKeywordsDistinct();
 }

--- a/src/main/java/com/palangwi/soup/schedule/CollectNewsScheduler.java
+++ b/src/main/java/com/palangwi/soup/schedule/CollectNewsScheduler.java
@@ -19,7 +19,7 @@ public class CollectNewsScheduler {
     private final KeywordRepository keywordRepository;
     private final NewsService newsService;
 
-    @Scheduled(cron = "0 0 6 * * *")
+    @Scheduled(cron = "0 45 17 * * *")
     private void collectNews() {
         List<Keyword> keywords = keywordRepository.findAll();
         log.info("수집 시작 - 키워드의 갯수 : {}", keywords.size());

--- a/src/main/java/com/palangwi/soup/schedule/CollectNewsScheduler.java
+++ b/src/main/java/com/palangwi/soup/schedule/CollectNewsScheduler.java
@@ -19,7 +19,7 @@ public class CollectNewsScheduler {
     private final KeywordRepository keywordRepository;
     private final NewsService newsService;
 
-    @Scheduled(cron = "0 45 17 * * *")
+    @Scheduled(cron = "0 0 7 * * *")
     private void collectNews() {
         List<Keyword> keywords = keywordRepository.findAll();
         log.info("수집 시작 - 키워드의 갯수 : {}", keywords.size());

--- a/src/main/java/com/palangwi/soup/schedule/MailScheduler.java
+++ b/src/main/java/com/palangwi/soup/schedule/MailScheduler.java
@@ -32,7 +32,7 @@ public class MailScheduler {
     private final UserKeywordRepository userKeywordRepository;
     private final MailService mailService;
 
-    @Scheduled(cron = "0 46 17 * * 1-5", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 8 * * 1-5", zone = "Asia/Seoul")
     public void scheduleDailyNewsLetter() {
         log.info("뉴스 메일 발송 시작");
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/palangwi/soup/schedule/MailScheduler.java
+++ b/src/main/java/com/palangwi/soup/schedule/MailScheduler.java
@@ -32,7 +32,7 @@ public class MailScheduler {
     private final UserKeywordRepository userKeywordRepository;
     private final MailService mailService;
 
-    @Scheduled(cron = "0 0 7 * * 1-5", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 46 17 * * 1-5", zone = "Asia/Seoul")
     public void scheduleDailyNewsLetter() {
         log.info("뉴스 메일 발송 시작");
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/palangwi/soup/service/mail/MailService.java
+++ b/src/main/java/com/palangwi/soup/service/mail/MailService.java
@@ -4,11 +4,14 @@ import com.palangwi.soup.domain.mail.MailEvent;
 import com.palangwi.soup.domain.mail.policy.NewsSelectionPolicy;
 import com.palangwi.soup.domain.news.Summary;
 import com.palangwi.soup.domain.user.User;
+import com.palangwi.soup.dto.admin.email.EmailTestResponseDto;
 import com.palangwi.soup.dto.mail.MailMessage;
 import com.palangwi.soup.dto.news.DailyNewsMailRequestDto;
 import com.palangwi.soup.dto.news.SummaryForMailTemplateDto;
+import com.palangwi.soup.exception.user.UserNotFoundException;
 import com.palangwi.soup.infrastructure.mail.MailViewRenderer;
 import com.palangwi.soup.repository.mail.MailEventRepository;
+import com.palangwi.soup.repository.user.UserRepository;
 import java.util.Base64;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +24,7 @@ import java.util.Map;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.palangwi.soup.domain.mail.MailType.DAILY_NEWS;
+import static com.palangwi.soup.domain.mail.MailType.TEST;
 
 @Slf4j
 @Service
@@ -31,6 +35,7 @@ public class MailService {
     private final MailAsyncExecutor mailAsyncExecutor;
     private final MailViewRenderer mailViewRenderer;
     private final NewsSelectionPolicy newsSelectionPolicy;
+    private final UserRepository userRepository;
 
     private static final byte[] TRANSPARENT_PIXEL = Base64.getDecoder().decode(
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
@@ -49,18 +54,12 @@ public class MailService {
 
         MailEvent mailEvent = getMailEvent(user, now);
 
-        List<SummaryForMailTemplateDto> summaryForMail = summaryMap.entrySet().stream()
-                .map(entry -> new SummaryForMailTemplateDto(
-                        entry.getKey(),
-                        entry.getValue().getShortSummary()
-                ))
-                .toList();
+        List<SummaryForMailTemplateDto> summaryForMail = convertToMailTemplateDtos(summaryMap);
 
          String html = mailViewRenderer.renderDailyNews(user.getUsername(), summaryForMail, mailEvent.getId());
 
-        MailMessage message = new MailMessage(
-                user.getId(),
-                user.getEmail(),
+        MailMessage message = MailMessage.of(
+                user,
                 "오늘의 수프",
                 html,
                 DAILY_NEWS,
@@ -93,5 +92,46 @@ public class MailService {
 
     private byte[] getTransparentPixel() {
         return TRANSPARENT_PIXEL;
+    }
+
+    public EmailTestResponseDto testMail(Long id) {
+        User user = findUserById(id);
+
+        List<String> fixedKeywords = List.of("AI");
+        Map<String, Summary> summaryMap = newsSelectionPolicy.select(fixedKeywords);
+
+        if (summaryMap.isEmpty()) {
+            throw new IllegalStateException("테스트용 메일을 생성할 수 있는 뉴스 요약이 없습니다.");
+        }
+
+        List<SummaryForMailTemplateDto> summaryForMail = convertToMailTemplateDtos(summaryMap);
+
+        String html = mailViewRenderer.renderDailyNews(user.getUsername(), summaryForMail, -1L);
+
+        MailMessage message = MailMessage.of(
+                user,
+                "[테스트] 오늘의 수프",
+                html,
+                TEST,
+                -1L
+        );
+
+        mailAsyncExecutor.send(message);
+
+        return EmailTestResponseDto.of(user);
+    }
+
+    private List<SummaryForMailTemplateDto> convertToMailTemplateDtos(Map<String, Summary> summaryMap) {
+        return summaryMap.entrySet().stream()
+                .map(entry -> new SummaryForMailTemplateDto(
+                        entry.getKey(),
+                        entry.getValue().getShortSummary()
+                ))
+                .toList();
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
     }
 }

--- a/src/main/java/com/palangwi/soup/service/mail/MailService.java
+++ b/src/main/java/com/palangwi/soup/service/mail/MailService.java
@@ -1,17 +1,22 @@
 package com.palangwi.soup.service.mail;
 
 import com.palangwi.soup.domain.mail.MailEvent;
+import com.palangwi.soup.domain.mail.MailType;
 import com.palangwi.soup.domain.mail.policy.NewsSelectionPolicy;
 import com.palangwi.soup.domain.news.Summary;
 import com.palangwi.soup.domain.user.User;
+import com.palangwi.soup.dto.admin.email.EmailScheduleResponseDto;
 import com.palangwi.soup.dto.admin.email.EmailTestResponseDto;
 import com.palangwi.soup.dto.mail.MailMessage;
 import com.palangwi.soup.dto.news.DailyNewsMailRequestDto;
 import com.palangwi.soup.dto.news.SummaryForMailTemplateDto;
+import com.palangwi.soup.exception.mail.MailNotFoundException;
 import com.palangwi.soup.exception.user.UserNotFoundException;
 import com.palangwi.soup.infrastructure.mail.MailViewRenderer;
 import com.palangwi.soup.repository.mail.MailEventRepository;
 import com.palangwi.soup.repository.user.UserRepository;
+import com.palangwi.soup.repository.userkeyword.UserKeywordRepository;
+import com.palangwi.soup.utils.ApiUtils.ApiResult;
 import java.util.Base64;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -37,9 +42,12 @@ public class MailService {
     private final NewsSelectionPolicy newsSelectionPolicy;
     private final UserRepository userRepository;
 
+    private static final long TEST_MAIL_EVENT_ID = -1L;
+
     private static final byte[] TRANSPARENT_PIXEL = Base64.getDecoder().decode(
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
     );
+    private final UserKeywordRepository userKeywordRepository;
 
     @Transactional
     public void sendDailyNews(DailyNewsMailRequestDto request) {
@@ -52,7 +60,7 @@ public class MailService {
         Map<String, Summary> summaryMap = newsSelectionPolicy.select(request.keywords());
         if (summaryMap.isEmpty()) return;
 
-        MailEvent mailEvent = getMailEvent(user, now);
+        MailEvent mailEvent = createMailEvent(user, now);
 
         List<SummaryForMailTemplateDto> summaryForMail = convertToMailTemplateDtos(summaryMap);
 
@@ -69,7 +77,7 @@ public class MailService {
         mailAsyncExecutor.send(message);
     }
 
-    private MailEvent getMailEvent(User user, LocalDateTime now) {
+    private MailEvent createMailEvent(User user, LocalDateTime now) {
         MailEvent mailEvent = new MailEvent(user.getId(), DAILY_NEWS, now, false);
         mailEventRepository.save(mailEvent);
         return mailEvent;
@@ -96,6 +104,7 @@ public class MailService {
 
     public EmailTestResponseDto testMail(Long id) {
         User user = findUserById(id);
+        LocalDateTime sentAt = LocalDateTime.now();
 
         List<String> fixedKeywords = List.of("AI");
         Map<String, Summary> summaryMap = newsSelectionPolicy.select(fixedKeywords);
@@ -113,12 +122,12 @@ public class MailService {
                 "[테스트] 오늘의 수프",
                 html,
                 TEST,
-                -1L
+                TEST_MAIL_EVENT_ID
         );
 
         mailAsyncExecutor.send(message);
 
-        return EmailTestResponseDto.of(user);
+        return EmailTestResponseDto.of(user, sentAt);
     }
 
     private List<SummaryForMailTemplateDto> convertToMailTemplateDtos(Map<String, Summary> summaryMap) {
@@ -133,5 +142,24 @@ public class MailService {
     private User findUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
+    }
+
+    public EmailScheduleResponseDto getMailSchedule() {
+        Optional<MailEvent> lastEventLog = mailEventRepository.findTopByTypeOrderByCreatedDateDesc(DAILY_NEWS);
+
+        String lastStatus = lastEventLog.map(e -> e.isSendSuccess() ? "SUCCESS" : "FAIL").orElse("MAIL NOT FOUND");
+        String lastExecutionTime = lastEventLog.map(e -> e.getSentAt().toString()).orElse("MAIL NOT FOUND");
+
+        String nextExecutionTime = calculateNextExecutionTime();
+        int activeTasks = userKeywordRepository.findAllSubscribedUserKeywordsDistinct().size();
+
+        return EmailScheduleResponseDto.of(lastStatus, lastExecutionTime, nextExecutionTime, activeTasks);
+    }
+
+    private String calculateNextExecutionTime() {
+        return LocalDateTime.now()
+                .withHour(8).withMinute(0).withSecond(0).withNano(0)
+                .plusDays(1)
+                .toString();
     }
 }

--- a/src/main/java/com/palangwi/soup/service/mail/MailService.java
+++ b/src/main/java/com/palangwi/soup/service/mail/MailService.java
@@ -102,7 +102,7 @@ public class MailService {
         return TRANSPARENT_PIXEL;
     }
 
-    public EmailTestResponseDto testMail(Long id) {
+    public EmailTestResponseDto testEmail(Long id) {
         User user = findUserById(id);
         LocalDateTime sentAt = LocalDateTime.now();
 

--- a/src/main/java/com/palangwi/soup/service/mail/MailService.java
+++ b/src/main/java/com/palangwi/soup/service/mail/MailService.java
@@ -110,12 +110,12 @@ public class MailService {
         Map<String, Summary> summaryMap = newsSelectionPolicy.select(fixedKeywords);
 
         if (summaryMap.isEmpty()) {
-            throw new IllegalStateException("테스트용 메일을 생성할 수 있는 뉴스 요약이 없습니다.");
+            throw new MailNotFoundException();
         }
 
         List<SummaryForMailTemplateDto> summaryForMail = convertToMailTemplateDtos(summaryMap);
 
-        String html = mailViewRenderer.renderDailyNews(user.getUsername(), summaryForMail, -1L);
+        String html = mailViewRenderer.renderDailyNews(user.getUsername(), summaryForMail, TEST_MAIL_EVENT_ID);
 
         MailMessage message = MailMessage.of(
                 user,
@@ -147,8 +147,8 @@ public class MailService {
     public EmailScheduleResponseDto getMailSchedule() {
         Optional<MailEvent> lastEventLog = mailEventRepository.findTopByTypeOrderByCreatedDateDesc(DAILY_NEWS);
 
-        String lastStatus = lastEventLog.map(e -> e.isSendSuccess() ? "SUCCESS" : "FAIL").orElse("MAIL NOT FOUND");
-        String lastExecutionTime = lastEventLog.map(e -> e.getSentAt().toString()).orElse("MAIL NOT FOUND");
+        String lastStatus = lastEventLog.map(e -> e.isSendSuccess() ? "SUCCESS" : "FAIL").orElseThrow(MailNotFoundException::new);
+        String lastExecutionTime = lastEventLog.map(e -> e.getSentAt().toString()).orElseThrow(MailNotFoundException::new);
 
         String nextExecutionTime = calculateNextExecutionTime();
         int activeTasks = userKeywordRepository.findAllSubscribedUserKeywordsDistinct().size();


### PR DESCRIPTION
## 작업 내용
- 테스트용 메일 발송 기능 추가 (`/api/v1/mails/test`)
  - 고정 키워드 `"AI"`를 기준으로 요약 생성
  - 사용자 ID 기반 유저 조회 후 테스트 메일 전송
  - 발송 시각(`sentAt`) 포함 응답 반환
- 메일 발송 스케줄 조회 API 추가 (`/api/v1/mails/schedule`)
  - 마지막 발송 상태 (`lastStatus`: SUCCESS / FAIL / PENDING)
  - 마지막 발송 시각 (`lastExecutionTime`)
  - 다음 발송 예정 시각 (`nextExecutionTime`, 매일 08:00 기준)
  - 현재 구독 중인 사용자 수 (`activeTasks`)
- 관련 도메인 및 서비스 로직 정리
  - `MailService`, `MailEvent`, `MailViewRenderer` 개선

## 참고 사항
- 테스트 메일 발송은 `MailEvent`를 저장하지 않으며, 추적용 ID로 `-1L` 사용
- `schedule` API는 어드민 대시보드 등에서 발송 상태 확인 용도로 활용 가능
- 추후 실제 스케줄러와 연동 시 `nextExecutionTime` 계산 방식 변경 가능성 있음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added admin email API endpoints for sending test emails and viewing email schedule information.
  - Introduced the ability to send test emails to users.
  - Provided an endpoint to view the status and schedule of daily news emails, including last and next execution times.
- **Improvements**
  - Email links in daily news are now dynamically generated based on server configuration.
  - Updated daily news collection and email scheduling times to later morning hours.
- **Error Handling**
  - Enhanced error messages for missing mail events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->