### PR TITLE
[feature] 키워드 검색 기능 및 테스트 추가

### DIFF
--- a/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
+++ b/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
@@ -6,6 +6,7 @@ import com.palangwi.soup.dto.keyword.RequestKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.response.KeywordUnsubscribeResponseDto;
 import com.palangwi.soup.dto.keyword.response.RequestKeywordResponseDto;
+import com.palangwi.soup.dto.keyword.response.SearchKeywordsResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,38 +25,47 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Keyword API", description = "키워드 관련 API")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/keywords")
 public class KeywordController {
 
     private final KeywordService keywordService;
 
     @Operation(summary = "키워드 목록 조회", description = "키워드 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
-    @GetMapping("/api/v1/keywords")
+    @GetMapping
     public ApiResult<KeywordResponseDto> getKeywords() {
         return success(null);
     }
 
+    @Operation(summary = "키워드 검색", description = "키워드를 검색합니다.")
+    @ApiResponse(responseCode = "200", description = "검색 성공")
+    @GetMapping("/search")
+    public ApiResult<SearchKeywordsResponseDto> searchKeywords(
+            @AuthenticationPrincipal JwtAuthentication userDetails,
+            @RequestParam String keyword) {
+        return success(keywordService.searchKeywords(userDetails.id(), keyword));
+    }
+
     @Operation(summary = "키워드 구독", description = "새로운 키워드를 구독합니다.")
     @ApiResponse(responseCode = "200", description = "등록 성공")
-    @PostMapping("/api/v1/keywords")
+    @PostMapping
     public ApiResult<SubscribeKeywordResponseDto> subscribeKeyword(
             @AuthenticationPrincipal JwtAuthentication userDetails,
             @Valid @RequestBody SubscribeKeywordRequestDto subscribeKeywordRequestDto) {
         return success(keywordService.subscribeKeywords(userDetails.id(), subscribeKeywordRequestDto));
     }
 
-    @PostMapping("/api/v1/keywords/{keywordId}")
+    @PostMapping("/{keywordId}")
     public ApiResult<KeywordUnsubscribeResponseDto> unsubscribeKeyword(
             @AuthenticationPrincipal JwtAuthentication userDetails,
             @PathVariable Long keywordId) {
         return success(keywordService.unsubscribeKeyword(userDetails.id(), keywordId));
     }
 
-    @PostMapping("/api/v1/keywords/request")
+    @PostMapping("/request")
     public ApiResult<RequestKeywordResponseDto> requestKeywords(
             @AuthenticationPrincipal JwtAuthentication userDetails,
-            @Valid @RequestBody RequestKeywordRequestDto requestKeywordRequestDto
-    ) {
+            @Valid @RequestBody RequestKeywordRequestDto requestKeywordRequestDto) {
         return success(keywordService.requestKeywords(userDetails.id(), requestKeywordRequestDto));
     }
 }

--- a/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
+++ b/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
@@ -9,6 +9,8 @@ import com.palangwi.soup.dto.keyword.response.RequestKeywordResponseDto;
 import com.palangwi.soup.dto.keyword.response.SearchKeywordsResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -42,7 +44,7 @@ public class KeywordController {
     @GetMapping("/search")
     public ApiResult<SearchKeywordsResponseDto> searchKeywords(
             @AuthenticationPrincipal JwtAuthentication userDetails,
-            @RequestParam String keyword) {
+            @RequestParam @NotBlank @Size(min = 1, max = 100) String keyword) {
         return success(keywordService.searchKeywords(userDetails.id(), keyword));
     }
 

--- a/src/main/java/com/palangwi/soup/dto/keyword/response/SearchKeywordDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/response/SearchKeywordDto.java
@@ -1,0 +1,18 @@
+package com.palangwi.soup.dto.keyword.response;
+
+import com.palangwi.soup.domain.keyword.Keyword;
+
+public record SearchKeywordDto(
+        Long id,
+        String name,
+        String normalizedName,
+        boolean isSubscribed) {
+
+    public static SearchKeywordDto from(Keyword keyword, boolean isSubscribed) {
+        return new SearchKeywordDto(
+                keyword.getId(),
+                keyword.getName(),
+                keyword.getNormalizedName(),
+                isSubscribed);
+    }
+}

--- a/src/main/java/com/palangwi/soup/dto/keyword/response/SearchKeywordsResponseDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/response/SearchKeywordsResponseDto.java
@@ -1,0 +1,12 @@
+package com.palangwi.soup.dto.keyword.response;
+
+import java.util.List;
+
+
+public record SearchKeywordsResponseDto(
+        List<SearchKeywordDto> keywords) {
+
+    public static SearchKeywordsResponseDto from(List<SearchKeywordDto> keywords) {
+        return new SearchKeywordsResponseDto(keywords);
+    }
+}

--- a/src/main/java/com/palangwi/soup/repository/keyword/KeywordRepository.java
+++ b/src/main/java/com/palangwi/soup/repository/keyword/KeywordRepository.java
@@ -5,11 +5,13 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.palangwi.soup.domain.keyword.Keyword;
 
 public interface KeywordRepository extends JpaRepository<Keyword, Long> {
-    
+
     boolean existsByName(String name);
 
     boolean existsByNameAndStatus(String name, Status status);
@@ -19,4 +21,15 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
     List<Keyword> findAllByNameIn(List<String> names);
 
     Optional<Keyword> findByNameAndStatus(String name, Status status);
+
+    List<Keyword> findByNameContainingIgnoreCaseAndStatus(String name, Status status);
+
+    @Query("SELECT k, CASE WHEN uk.subscribed = true THEN true ELSE false END " +
+            "FROM Keyword k " +
+            "LEFT JOIN UserKeyword uk ON uk.keyword = k AND uk.user.id = :userId " +
+            "WHERE k.name LIKE %:keyword% AND k.status = :status")
+    List<Object[]> findKeywordsWithSubscriptionStatus(
+            @Param("userId") Long userId,
+            @Param("keyword") String keyword,
+            @Param("status") Status status);
 }

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordService.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordService.java
@@ -5,8 +5,8 @@ import com.palangwi.soup.dto.keyword.RequestKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.response.KeywordUnsubscribeResponseDto;
 import com.palangwi.soup.dto.keyword.response.RequestKeywordResponseDto;
+import com.palangwi.soup.dto.keyword.response.SearchKeywordsResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
-import jakarta.validation.Valid;
 
 public interface KeywordService {
 
@@ -23,4 +23,6 @@ public interface KeywordService {
     RequestKeywordResponseDto requestKeywords(Long userId, RequestKeywordRequestDto requestKeywordRequestDto);
 
     KeywordUnsubscribeResponseDto unsubscribeKeyword(Long id, Long keywordId);
+
+    SearchKeywordsResponseDto searchKeywords(Long userId, String keyword);
 }

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
@@ -8,6 +8,8 @@ import com.palangwi.soup.dto.keyword.RequestKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.response.KeywordUnsubscribeResponseDto;
 import com.palangwi.soup.dto.keyword.response.RequestKeywordResponseDto;
+import com.palangwi.soup.dto.keyword.response.SearchKeywordDto;
+import com.palangwi.soup.dto.keyword.response.SearchKeywordsResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
 import com.palangwi.soup.exception.keyword.*;
 import com.palangwi.soup.repository.keyword.PendingKeywordRequestRepository;
@@ -57,6 +59,21 @@ public class KeywordServiceImpl implements KeywordService {
 
     }
 
+    @Transactional(readOnly = true)
+    public SearchKeywordsResponseDto searchKeywords(Long userId, String keyword) {
+        List<Object[]> results = keywordRepository.findKeywordsWithSubscriptionStatus(userId, keyword, Status.ACTIVE);
+
+        List<SearchKeywordDto> keywords = results.stream()
+                .map(result -> {
+                    Keyword foundKeyword = (Keyword) result[0];
+                    boolean isSubscribed = (boolean) result[1];
+                    return SearchKeywordDto.from(foundKeyword, isSubscribed);
+                })
+                .toList();
+
+        return SearchKeywordsResponseDto.from(keywords);
+    }
+
     @Transactional
     public RequestKeywordResponseDto requestKeywords(Long userId, RequestKeywordRequestDto requestKeywordRequestDto) {
         User user = findUserById(userId);
@@ -93,7 +110,7 @@ public class KeywordServiceImpl implements KeywordService {
 
     @Transactional
     public SubscribeKeywordResponseDto subscribeKeywords(Long userId,
-                                                         SubscribeKeywordRequestDto subscribeKeywordRequestDto) {
+            SubscribeKeywordRequestDto subscribeKeywordRequestDto) {
         User user = findUserById(userId);
         List<String> keywordNames = subscribeKeywordRequestDto.subscribeKeywords();
 
@@ -103,8 +120,7 @@ public class KeywordServiceImpl implements KeywordService {
         return SubscribeKeywordResponseDto.of(
                 userKeywords.stream()
                         .map(userKeyword -> userKeyword.getKeyword().getName())
-                        .toList()
-        );
+                        .toList());
     }
 
     private void initPendingKeywordRequest(User user, Keyword keyword) {
@@ -143,7 +159,8 @@ public class KeywordServiceImpl implements KeywordService {
         return keywordMap;
     }
 
-    private List<UserKeyword> filterAndBuildUserKeywords(User user, List<String> keywordNames, Map<String, Keyword> keywordMap) {
+    private List<UserKeyword> filterAndBuildUserKeywords(User user, List<String> keywordNames,
+            Map<String, Keyword> keywordMap) {
         List<UserKeyword> result = new ArrayList<>();
         List<String> alreadySubscribed = new ArrayList<>();
 
@@ -159,8 +176,7 @@ public class KeywordServiceImpl implements KeywordService {
                             result.add(userKeyword);
                         }
                     },
-                    () -> result.add(UserKeyword.create(user, keyword))
-            );
+                    () -> result.add(UserKeyword.create(user, keyword)));
         }
 
         if (!alreadySubscribed.isEmpty()) {

--- a/src/test/java/com/palangwi/soup/controller/keyword/KeywordControllerTest.java
+++ b/src/test/java/com/palangwi/soup/controller/keyword/KeywordControllerTest.java
@@ -1,4 +1,4 @@
-package com.palangwi.soup.controller;
+package com.palangwi.soup.controller.keyword;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -9,6 +9,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
 import com.palangwi.soup.IntegrationTestSupport;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
+import com.palangwi.soup.dto.keyword.response.SearchKeywordDto;
+import com.palangwi.soup.dto.keyword.response.SearchKeywordsResponseDto;
 import com.palangwi.soup.service.keyword.KeywordService;
 import java.util.Arrays;
 import java.util.List;
@@ -28,11 +30,43 @@ class KeywordControllerTest extends IntegrationTestSupport {
     private KeywordService keywordService;
 
     @Test
+    @DisplayName("키워드 검색에 성공한다.")
+    @WithMockJwtAuthentication(id = 1L)
+    void searchKeywords_success() throws Exception {
+        // given
+        String searchKeyword = "자바";
+        List<SearchKeywordDto> keywords = Arrays.asList(
+                new SearchKeywordDto(1L, "자바", "java", true),
+                new SearchKeywordDto(2L, "자바스크립트", "javascript", false));
+        SearchKeywordsResponseDto response = new SearchKeywordsResponseDto(keywords);
+
+        given(keywordService.searchKeywords(1L, searchKeyword))
+                .willReturn(response);
+
+        // when // then
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/keywords/search")
+                .param("keyword", searchKeyword)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.keywords[0].id").value(1))
+                .andExpect(jsonPath("$.data.keywords[0].name").value("자바"))
+                .andExpect(jsonPath("$.data.keywords[0].normalizedName").value("java"))
+                .andExpect(jsonPath("$.data.keywords[0].isSubscribed").value(true))
+                .andExpect(jsonPath("$.data.keywords[1].id").value(2))
+                .andExpect(jsonPath("$.data.keywords[1].name").value("자바스크립트"))
+                .andExpect(jsonPath("$.data.keywords[1].normalizedName").value("javascript"))
+                .andExpect(jsonPath("$.data.keywords[1].isSubscribed").value(false));
+
+        verify(keywordService).searchKeywords(1L, searchKeyword);
+    }
+
+    @Test
     @DisplayName("키워드 등록에 성공한다.")
     @WithMockJwtAuthentication(id = 1L)
     void registerKeyword_success() throws Exception {
         // given
-
         SubscribeKeywordRequestDto request = new SubscribeKeywordRequestDto(Arrays.asList("키워드1", "키워드2"));
         SubscribeKeywordResponseDto response = new SubscribeKeywordResponseDto(Arrays.asList("키워드1", "키워드2"));
 
@@ -43,7 +77,7 @@ class KeywordControllerTest extends IntegrationTestSupport {
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/keywords")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
-                .andDo(print()) // 실제 응답 내용을 보기 위해 추가
+                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.registeredKeywords[0]").value("키워드1"))
@@ -58,7 +92,6 @@ class KeywordControllerTest extends IntegrationTestSupport {
     void registerKeyword_alreadySubscribed() throws Exception {
         // given
         SubscribeKeywordRequestDto request = new SubscribeKeywordRequestDto(Arrays.asList("키워드1"));
-        // 예외 발생 설정
         given(keywordService.subscribeKeywords(1L, request))
                 .willThrow(new AlreadySubscribedKeywordException(List.of("키워드1")));
 

--- a/src/test/java/com/palangwi/soup/repository/KeywordRepositoryTest.java
+++ b/src/test/java/com/palangwi/soup/repository/KeywordRepositoryTest.java
@@ -35,7 +35,7 @@ class KeywordRepositoryTest extends IntegrationTestSupport {
     @Autowired
     private UserRepository userRepository;
 
-    private static Long userId = 1L; // Assuming a user with ID 1 exists for testing
+    private Long userId;
 
     @BeforeEach
     void setUp() {
@@ -83,9 +83,9 @@ class KeywordRepositoryTest extends IntegrationTestSupport {
         assertThat(result).extracting("name").containsExactlyInAnyOrder("키워드1", "키워드2");
     }
 
-    @DisplayName("입력받은 키워드 이름이 포함된 키워드를 조회한다.")
+    @DisplayName("사용자의 구독 상태와 함께 키워드를 조회한다.")
     @Test
-    void findByNameContaining() {
+    void findKeywordsWithSubscriptionStatus() {
 
         List<Object[]> results = keywordRepository.findKeywordsWithSubscriptionStatus(userId, "키워드", PENDING);
         List<SearchKeywordDto> keywords = results.stream()

--- a/src/test/java/com/palangwi/soup/repository/KeywordRepositoryTest.java
+++ b/src/test/java/com/palangwi/soup/repository/KeywordRepositoryTest.java
@@ -1,9 +1,11 @@
 package com.palangwi.soup.repository;
 
+import static com.palangwi.soup.domain.keyword.Status.PENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palangwi.soup.domain.user.Gender;
 import com.palangwi.soup.domain.user.User;
+import com.palangwi.soup.dto.keyword.response.SearchKeywordDto;
 import com.palangwi.soup.repository.user.UserRepository;
 import com.palangwi.soup.security.Role;
 import java.time.LocalDate;
@@ -33,9 +35,12 @@ class KeywordRepositoryTest extends IntegrationTestSupport {
     @Autowired
     private UserRepository userRepository;
 
+    private static Long userId = 1L; // Assuming a user with ID 1 exists for testing
+
     @BeforeEach
     void setUp() {
         User user = createUser("테스트 닉네임");
+        userId = user.getId();
         Keyword keyword1 = Keyword.of("키워드1", "키워드1", Source.USER_REQUEST, user);
         Keyword keyword2 = Keyword.of("키워드2", "키워드2", Source.MANUAL, user);
         keywordRepository.saveAll(Arrays.asList(keyword1, keyword2));
@@ -76,6 +81,22 @@ class KeywordRepositoryTest extends IntegrationTestSupport {
         List<Keyword> result = keywordRepository.findAllByNameIn(Arrays.asList("키워드1", "키워드2", "없는키워드"));
         assertThat(result).hasSize(2);
         assertThat(result).extracting("name").containsExactlyInAnyOrder("키워드1", "키워드2");
+    }
+
+    @DisplayName("입력받은 키워드 이름이 포함된 키워드를 조회한다.")
+    @Test
+    void findByNameContaining() {
+
+        List<Object[]> results = keywordRepository.findKeywordsWithSubscriptionStatus(userId, "키워드", PENDING);
+        List<SearchKeywordDto> keywords = results.stream()
+                .map(result -> {
+                    Keyword foundKeyword = (Keyword) result[0];
+                    boolean isSubscribed = (boolean) result[1];
+                    return SearchKeywordDto.from(foundKeyword, isSubscribed);
+                })
+                .toList();
+        assertThat(keywords).hasSize(2);
+        assertThat(keywords).extracting("name").containsExactlyInAnyOrder("키워드1", "키워드2");
     }
 
     private User createUser(String nickname) {

--- a/src/test/java/com/palangwi/soup/service/keyword/KeywordServiceTest.java
+++ b/src/test/java/com/palangwi/soup/service/keyword/KeywordServiceTest.java
@@ -8,12 +8,12 @@ import com.palangwi.soup.domain.keyword.Keyword;
 import com.palangwi.soup.domain.keyword.Source;
 import com.palangwi.soup.domain.user.Gender;
 import com.palangwi.soup.domain.user.User;
-
 import com.palangwi.soup.domain.userkeyword.UserKeyword;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
+import com.palangwi.soup.dto.keyword.response.SearchKeywordDto;
+import com.palangwi.soup.dto.keyword.response.SearchKeywordsResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
 import com.palangwi.soup.exception.keyword.AlreadySubscribedKeywordException;
-
 import com.palangwi.soup.repository.keyword.KeywordRepository;
 import com.palangwi.soup.repository.user.UserRepository;
 import com.palangwi.soup.repository.userkeyword.UserKeywordRepository;
@@ -88,5 +88,59 @@ class KeywordServiceTest extends IntegrationTestSupport {
         assertThat(result.registeredKeywords()).hasSize(2);
         assertThat(keywordRepository.findAll()).hasSize(2);
         assertThat(userKeywordRepository.findAll()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("검색 키워드가 정상적으로 조회된다.")
+    void searchKeywords_정상() {
+        // given
+        User user = createUser("테스트 닉네임");
+        Keyword keyword1 = Keyword.of("자바", "java", Source.USER_REQUEST, user);
+        Keyword keyword2 = Keyword.of("자바스크립트", "javascript", Source.USER_REQUEST, user);
+        Keyword keyword3 = Keyword.of("파이썬", "python", Source.USER_REQUEST, user);
+        keywordRepository.saveAll(Arrays.asList(keyword1, keyword2, keyword3));
+
+        userKeywordRepository.saveAll(List.of(UserKeyword.create(user, keyword1)));
+
+        String searchKeyword = "자바";
+        keyword1.approve(user);
+        keyword2.approve(user);
+        // when
+        SearchKeywordsResponseDto response = keywordService.searchKeywords(user.getId(), searchKeyword);
+
+        // then
+        assertThat(response.keywords()).hasSize(2);
+        assertThat(response.keywords().stream().map(SearchKeywordDto::name).toList())
+                .containsExactly("자바", "자바스크립트");
+        assertThat(response.keywords().get(0).name()).isEqualTo("자바");
+        assertThat(response.keywords().get(0).normalizedName()).isEqualTo("java");
+        assertThat(response.keywords().get(0).isSubscribed()).isTrue();
+        assertThat(response.keywords().get(1).name()).isEqualTo("자바스크립트");
+        assertThat(response.keywords().get(1).normalizedName()).isEqualTo("javascript");
+        assertThat(response.keywords().get(1).isSubscribed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("부분 일치 검색이 정상적으로 동작한다.")
+    void searchKeywords_부분일치() {
+        // given
+        User user = createUser("테스트 닉네임");
+        Keyword keyword1 = Keyword.of("자바", "java", Source.USER_REQUEST, user);
+        Keyword keyword2 = Keyword.of("자바스크립트", "javascript", Source.USER_REQUEST, user);
+        Keyword keyword3 = Keyword.of("파이썬", "python", Source.USER_REQUEST, user);
+
+        String searchKeyword = "자";
+        keyword1.approve(user);
+        keyword2.approve(user);
+
+        keywordRepository.saveAll(Arrays.asList(keyword1, keyword2, keyword3));
+
+        // when
+        SearchKeywordsResponseDto response = keywordService.searchKeywords(user.getId(), searchKeyword);
+
+        // then
+        assertThat(response.keywords()).hasSize(2);
+        assertThat(response.keywords().stream().map(SearchKeywordDto::name).toList())
+                .containsExactly("자바", "자바스크립트");
     }
 }


### PR DESCRIPTION
## 변경 사항 요약
키워드 검색 기능 추가 및 관련 클래스 수정

## 주요 변경 내용
이 PR은 키워드 검색 API를 구현하기 위해 여러 클래스를 수정하였습니다. KeywordController에 키워드 검색을 처리하는 메소드를 추가하고, 이에 적합한 DTO를 정의하였습니다. KeywordRepository에 사용자의 구독 상태를 포함한 키워드 검색 쿼리를 추가하였으며, KeywordService에서 이를 호출하는 로직을 구현했습니다. 테스트 코드도 추가하여 기능의 정상 작동을 검증했습니다.
