### PR TITLE
[chore] CI 결과 알림 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,16 +128,28 @@ jobs:
           name: build-reports
           path: build/reports/
 
-      - name: Notify Mattermost on Success
+      - name: Notify Mattermost on Build Success
         if: success()
-        uses: 7c/mattermost-notify@v1
+        uses: fjogeleit/http-request-action@v1.14.0
         with:
-          webhook-url: ${{ env.MATTERMOST_WEBHOOK_URL }}
-          message: "✅ CI 성공: ${{ github.repository }}의 PR #${{ github.event.pull_request.number }} 빌드가 성공했습니다."
+          url: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          method: "POST"
+          customHeaders: |
+            Content-Type: application/json
+          data: |
+            {
+              "text": ":green_heart: CI 빌드 성공 - `${{ github.repository }}` PR #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}"
+            }
 
-      - name: Notify Mattermost on Failure
+      - name: Notify Mattermost on Build Failure
         if: failure()
-        uses: 7c/mattermost-notify@v1
+        uses: fjogeleit/http-request-action@v1.14.0
         with:
-          webhook-url: ${{ env.MATTERMOST_WEBHOOK_URL }}
-          message: "❌ CI 실패: ${{ github.repository }}의 PR #${{ github.event.pull_request.number }} 빌드가 실패했습니다."
+          url: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          method: "POST"
+          customHeaders: |
+            Content-Type: application/json
+          data: |
+            {
+              "text": ":broken_heart: CI 빌드 실패 - `${{ github.repository }}` PR #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}"
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       JWT_CLIENT_SECRET: test
       FRONT_DOMAIN: http://localhost:5173
       SERVER_DOMAIN: https://soupspoon.kr/api/v1
+      MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
 
     steps:
       - uses: actions/checkout@v4
@@ -126,3 +127,17 @@ jobs:
         with:
           name: build-reports
           path: build/reports/
+
+      - name: Notify Mattermost on Success
+        if: success()
+        uses: 7c/mattermost-notify@v1
+        with:
+          webhook-url: ${{ env.MATTERMOST_WEBHOOK_URL }}
+          message: "✅ CI 성공: ${{ github.repository }}의 PR #${{ github.event.pull_request.number }} 빌드가 성공했습니다."
+
+      - name: Notify Mattermost on Failure
+        if: failure()
+        uses: 7c/mattermost-notify@v1
+        with:
+          webhook-url: ${{ env.MATTERMOST_WEBHOOK_URL }}
+          message: "❌ CI 실패: ${{ github.repository }}의 PR #${{ github.event.pull_request.number }} 빌드가 실패했습니다."


### PR DESCRIPTION
```json
{
    "description": {
        "summary": "CI 빌드 성공 및 실패 시 Mattermost에 알림을 추가하는 변경사항.",
        "details": "이 PR은 CI/CD 파이프라인에서 빌드 성공 또는 실패 여부에 따라 Mattermost에 알림을 보내는 기능을 추가합니다. 성공 시에는 초록색 하트 이모지와 함께 'CI 빌드 성공' 메시지가, 실패 시에는 깨진 하트 이모지와 함께 'CI 빌드 실패' 메시지가 전송됩니다. 알림 메시지에는 PR 번호와 제목이 포함되어 있습니다."
    },
    "review": {
        "critical_issues": [],
        "has_issues": false
    }
}
```