### PR TITLE
[feat] 내가 구독중인 키워드 조회하는 기능 개발

### DIFF
--- a/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
+++ b/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
@@ -24,34 +24,35 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Keyword API", description = "키워드 관련 API")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/keywords")
 public class KeywordController {
 
     private final KeywordService keywordService;
 
     @Operation(summary = "키워드 목록 조회", description = "키워드 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
-    @GetMapping("/api/v1/keywords")
+    @GetMapping
     public ApiResult<KeywordResponseDto> getKeywords() {
         return success(null);
     }
 
     @Operation(summary = "키워드 구독", description = "새로운 키워드를 구독합니다.")
     @ApiResponse(responseCode = "200", description = "등록 성공")
-    @PostMapping("/api/v1/keywords")
+    @PostMapping
     public ApiResult<SubscribeKeywordResponseDto> subscribeKeyword(
             @AuthenticationPrincipal JwtAuthentication userDetails,
             @Valid @RequestBody SubscribeKeywordRequestDto subscribeKeywordRequestDto) {
         return success(keywordService.subscribeKeywords(userDetails.id(), subscribeKeywordRequestDto));
     }
 
-    @PostMapping("/api/v1/keywords/{keywordId}")
+    @PostMapping("/{keywordId}")
     public ApiResult<KeywordUnsubscribeResponseDto> unsubscribeKeyword(
             @AuthenticationPrincipal JwtAuthentication userDetails,
             @PathVariable Long keywordId) {
         return success(keywordService.unsubscribeKeyword(userDetails.id(), keywordId));
     }
 
-    @PostMapping("/api/v1/keywords/request")
+    @PostMapping("/request")
     public ApiResult<RequestKeywordResponseDto> requestKeywords(
             @AuthenticationPrincipal JwtAuthentication userDetails,
             @Valid @RequestBody RequestKeywordRequestDto requestKeywordRequestDto

--- a/src/main/java/com/palangwi/soup/controller/user/UserController.java
+++ b/src/main/java/com/palangwi/soup/controller/user/UserController.java
@@ -2,55 +2,70 @@ package com.palangwi.soup.controller.user;
 
 import static com.palangwi.soup.utils.ApiUtils.success;
 
+import com.palangwi.soup.dto.keyword.MyKeywordListResponseDto;
 import com.palangwi.soup.dto.user.UserDeleteRequestDto;
 import com.palangwi.soup.dto.user.UserAdditionalInfoRequestDto;
 import com.palangwi.soup.dto.user.UserInitSettingResponseDto;
 import com.palangwi.soup.dto.user.UserResponseDto;
 import com.palangwi.soup.dto.user.UserUpdateRequestDto;
 import com.palangwi.soup.security.JwtAuthentication;
+import com.palangwi.soup.service.keyword.KeywordService;
 import com.palangwi.soup.service.user.UserService;
 import com.palangwi.soup.utils.ApiUtils.ApiResult;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
 public class UserController {
 
     private final UserService userService;
+    private final KeywordService keywordService;
 
-    @PostMapping("/api/v1/users/init")
+    @PostMapping("/init")
     public ApiResult<UserInitSettingResponseDto> initAdditionalInfo(@AuthenticationPrincipal JwtAuthentication userInfo,
                                                                     @Valid @RequestBody UserAdditionalInfoRequestDto request) {
         return success(userService.initAdditionalUserInfo(userInfo.id(), request));
     }
 
-    @PatchMapping("/api/v1/users")
+    @PatchMapping
     public ApiResult<UserResponseDto> updateUser(@AuthenticationPrincipal JwtAuthentication userInfo,
                                                  @Valid @RequestBody UserUpdateRequestDto request) {
         return success(userService.updateUserInfo(userInfo.id(), request));
     }
 
-    @GetMapping("/api/v1/users")
+    @GetMapping
     public ApiResult<UserResponseDto> getUserInfo(@AuthenticationPrincipal JwtAuthentication userInfo) {
         return success(userService.getUserInfo(userInfo.id()));
     }
 
-    @GetMapping("/api/v1/users/check-nickname")
+    @GetMapping("/check-nickname")
     public ApiResult<Boolean> validateNickname(@RequestParam(name = "nickname") String nickname) {
         return success(userService.isAvailableNickname(nickname)); // 길이, 형식만 체크
     }
 
-    @PostMapping("/api/v1/users/delete")
+    @PostMapping("/delete")
     public ApiResult<Void> deleteAccount(@AuthenticationPrincipal JwtAuthentication userInfo, @RequestBody UserDeleteRequestDto request) {
         userService.deleteAccount(userInfo.id(), request);
         return success();
+    }
+
+    @GetMapping("/me/keywords")
+    public ApiResult<MyKeywordListResponseDto> getMyKeywords (
+            @AuthenticationPrincipal JwtAuthentication userDetails,
+            @PageableDefault(size = 20, sort = "createdDate", direction = Direction.DESC) Pageable pageable) {
+        return success(keywordService.getMyKeywords(userDetails.id(), pageable));
     }
 }

--- a/src/main/java/com/palangwi/soup/dto/keyword/MyKeywordDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/MyKeywordDto.java
@@ -1,0 +1,10 @@
+package com.palangwi.soup.dto.keyword;
+
+import com.palangwi.soup.domain.userkeyword.UserKeyword;
+import java.time.LocalDateTime;
+
+public record MyKeywordDto(Long userId, String keyword, String normalizedKeyword, LocalDateTime registeredDate) {
+    public static MyKeywordDto of(UserKeyword userKeyword) {
+        return new MyKeywordDto(userKeyword.getId(), userKeyword.getKeyword().getName(), userKeyword.getKeyword().getNormalizedName(), userKeyword.getLastModifiedDate());
+    }
+}

--- a/src/main/java/com/palangwi/soup/dto/keyword/MyKeywordDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/MyKeywordDto.java
@@ -5,6 +5,6 @@ import java.time.LocalDateTime;
 
 public record MyKeywordDto(Long userId, String keyword, String normalizedKeyword, LocalDateTime registeredDate) {
     public static MyKeywordDto of(UserKeyword userKeyword) {
-        return new MyKeywordDto(userKeyword.getId(), userKeyword.getKeyword().getName(), userKeyword.getKeyword().getNormalizedName(), userKeyword.getLastModifiedDate());
+        return new MyKeywordDto(userKeyword.getUser().getId(), userKeyword.getKeyword().getName(), userKeyword.getKeyword().getNormalizedName(), userKeyword.getLastModifiedDate());
     }
 }

--- a/src/main/java/com/palangwi/soup/dto/keyword/MyKeywordListResponseDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/MyKeywordListResponseDto.java
@@ -1,0 +1,22 @@
+package com.palangwi.soup.dto.keyword;
+
+import com.palangwi.soup.domain.userkeyword.UserKeyword;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record MyKeywordListResponseDto(
+        List<MyKeywordDto> myKeywordDtos,
+        long totalElements,
+        int totalPages,
+        int currentPages
+) {
+    public static MyKeywordListResponseDto of(List<MyKeywordDto> myKeywordDtos, Page<UserKeyword> userKeywordPage) {
+        return new MyKeywordListResponseDto(
+                myKeywordDtos,
+                userKeywordPage.getTotalElements(),
+                userKeywordPage.getTotalPages(),
+                userKeywordPage.getNumber()
+        );
+    }
+}

--- a/src/main/java/com/palangwi/soup/repository/userkeyword/UserKeywordRepository.java
+++ b/src/main/java/com/palangwi/soup/repository/userkeyword/UserKeywordRepository.java
@@ -23,5 +23,5 @@ public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> 
     @Query("SELECT uk FROM UserKeyword uk WHERE uk.user.id = :userId AND uk.keyword.id = :keywordId AND uk.subscribed = true")
     Optional<UserKeyword> findSubscribedByUserIdAndKeywordId(@Param("userId") Long userId, @Param("keywordId") Long keywordId);
 
-    Page<UserKeyword> findAllByUser_Id(Long userId, Pageable pageable);
+    Page<UserKeyword> findAllByUser_IdAndSubscribedTrue(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/palangwi/soup/repository/userkeyword/UserKeywordRepository.java
+++ b/src/main/java/com/palangwi/soup/repository/userkeyword/UserKeywordRepository.java
@@ -4,6 +4,8 @@ import com.palangwi.soup.domain.userkeyword.UserKeyword;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,4 +22,6 @@ public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> 
 
     @Query("SELECT uk FROM UserKeyword uk WHERE uk.user.id = :userId AND uk.keyword.id = :keywordId AND uk.subscribed = true")
     Optional<UserKeyword> findSubscribedByUserIdAndKeywordId(@Param("userId") Long userId, @Param("keywordId") Long keywordId);
+
+    Page<UserKeyword> findAllByUser_Id(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordService.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordService.java
@@ -1,12 +1,13 @@
 package com.palangwi.soup.service.keyword;
 
 import com.palangwi.soup.dto.keyword.KeywordResponseDto;
+import com.palangwi.soup.dto.keyword.MyKeywordListResponseDto;
 import com.palangwi.soup.dto.keyword.RequestKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.response.KeywordUnsubscribeResponseDto;
 import com.palangwi.soup.dto.keyword.response.RequestKeywordResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
-import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
 
 public interface KeywordService {
 
@@ -23,4 +24,6 @@ public interface KeywordService {
     RequestKeywordResponseDto requestKeywords(Long userId, RequestKeywordRequestDto requestKeywordRequestDto);
 
     KeywordUnsubscribeResponseDto unsubscribeKeyword(Long id, Long keywordId);
+
+    MyKeywordListResponseDto getMyKeywords(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
@@ -4,11 +4,14 @@ import static com.palangwi.soup.utils.KeywordNormalizer.*;
 
 import com.palangwi.soup.domain.keyword.PendingKeywordRequest;
 import com.palangwi.soup.domain.keyword.Status;
+import com.palangwi.soup.dto.keyword.MyKeywordDto;
+import com.palangwi.soup.dto.keyword.MyKeywordListResponseDto;
 import com.palangwi.soup.dto.keyword.RequestKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.response.KeywordUnsubscribeResponseDto;
 import com.palangwi.soup.dto.keyword.response.RequestKeywordResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
+import com.palangwi.soup.dto.news.NewsDto;
 import com.palangwi.soup.exception.keyword.*;
 import com.palangwi.soup.repository.keyword.PendingKeywordRequestRepository;
 
@@ -16,6 +19,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -75,6 +80,17 @@ public class KeywordServiceImpl implements KeywordService {
                 .orElseThrow(NotSubscribedException::new);
         userKeyword.unsubscribe();
         return KeywordUnsubscribeResponseDto.of(userKeyword);
+    }
+
+    @Transactional(readOnly = true)
+    public MyKeywordListResponseDto getMyKeywords(Long userId, Pageable pageable) {
+        Page<UserKeyword> userKeywords = userKeywordRepository.findAllByUser_Id(userId, pageable);
+
+        List<MyKeywordDto> userKeywordList = userKeywords.getContent().stream()
+                .map(MyKeywordDto::of)
+                .toList();
+
+        return MyKeywordListResponseDto.of(userKeywordList, userKeywords);
     }
 
     private Keyword findOrCreateKeyword(String requestedKeyword, User user) {

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
@@ -100,7 +100,7 @@ public class KeywordServiceImpl implements KeywordService {
 
     @Transactional(readOnly = true)
     public MyKeywordListResponseDto getMyKeywords(Long userId, Pageable pageable) {
-        Page<UserKeyword> userKeywords = userKeywordRepository.findAllByUser_Id(userId, pageable);
+        Page<UserKeyword> userKeywords = userKeywordRepository.findAllByUser_IdAndSubscribedTrue(userId, pageable);
 
         List<MyKeywordDto> userKeywordList = userKeywords.getContent().stream()
                 .map(MyKeywordDto::of)

--- a/src/main/java/com/palangwi/soup/service/news/OpenAIService.java
+++ b/src/main/java/com/palangwi/soup/service/news/OpenAIService.java
@@ -6,6 +6,8 @@ import com.palangwi.soup.dto.news.NewsResult;
 import com.palangwi.soup.dto.news.NewsSummary;
 import com.palangwi.soup.dto.news.OpenAIWebSearchRequestDto;
 import com.palangwi.soup.dto.news.OpenAIWebSearchResponseDto;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
@@ -40,7 +42,8 @@ public class OpenAIService {
         CompletableFuture<NewsResult> future = new CompletableFuture<>();
 
         try {
-            String prompt = loadPrompt("prompts/news-prompt.txt").replace("{keyword}", keyword);
+            String today = getTodayString();
+            String prompt = loadPrompt().replace("{keyword}", keyword).replace("{today}", today);
             Request request = buildOpenAIRequest(prompt);
 
             client.newCall(request).enqueue(new Callback() {
@@ -70,6 +73,12 @@ public class OpenAIService {
         }
 
         return future;
+    }
+
+    private static String getTodayString() {
+        LocalDate today = LocalDate.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일");
+        return today.format(formatter);
     }
 
     private NewsResult parseOpenAIResponse(Response response) throws IOException {
@@ -122,11 +131,11 @@ public class OpenAIService {
                 .build();
     }
 
-    private String loadPrompt(String path) {
-        try (InputStream is = new ClassPathResource(path).getInputStream()) {
+    private String loadPrompt() {
+        try (InputStream is = new ClassPathResource("prompts/news-prompt.txt").getInputStream()) {
             return new String(is.readAllBytes(), StandardCharsets.UTF_8);
         } catch (Exception e) {
-            throw new RuntimeException("프롬프트 파일 로딩 실패: " + path, e);
+            throw new RuntimeException("프롬프트 파일 로딩 실패: " + "prompts/news-prompt.txt", e);
         }
     }
 }


### PR DESCRIPTION
## 변경 사항 요약
사용자의 키워드를 관리하는 새로운 API 엔드포인트와 관련된 기능 구현

## 주요 변경 내용
UserController에 '/me/keywords' 엔드포인트가 추가되어, 사용자의 키워드를 페이지네이션을 포함하여 조회할 수 있게 되었다. 이 기능은 KeywordService 및 KeywordServiceImpl을 통해 구현되며, MyKeywordDto 및 MyKeywordListResponseDto를 사용하여 응답을 구성한다. UserKeywordRepository에서 페이지네이션을 지원하는 쿼리가 추가되었으며, 전체 키워드 수와 페이지 정보를 포함하는 응답 형태가 정의되었다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new endpoint to view a paginated list of your subscribed keywords, including keyword details and registration date.
- **Improvements**
  - Enhanced keyword management with detailed keyword and pagination information in responses.
  - Improved API consistency by streamlining endpoint paths.
- **Bug Fixes**
  - Ensured the current date is included in news summary prompts for more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->