### PR TITLE
[feat] 키워드 전체 리스트 조회 기능 추가

### DIFF
--- a/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
+++ b/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
@@ -2,6 +2,7 @@ package com.palangwi.soup.controller.keyword;
 
 import static com.palangwi.soup.utils.ApiUtils.success;
 
+import com.palangwi.soup.dto.keyword.KeywordListResponseDto;
 import com.palangwi.soup.dto.keyword.RequestKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.response.KeywordUnsubscribeResponseDto;
@@ -11,6 +12,9 @@ import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,8 +39,11 @@ public class KeywordController {
     @Operation(summary = "키워드 목록 조회", description = "키워드 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping
-    public ApiResult<KeywordResponseDto> getKeywords() {
-        return success(null);
+    public ApiResult<KeywordListResponseDto> getKeywordList(
+            @AuthenticationPrincipal JwtAuthentication userDetails,
+            @PageableDefault(size = 20, sort = {"createdDate", "name"}, direction = Direction.DESC) Pageable pageable
+    ) {
+        return success(keywordService.getKeywordList(pageable));
     }
 
     @Operation(summary = "키워드 검색", description = "키워드를 검색합니다.")

--- a/src/main/java/com/palangwi/soup/controller/news/NewsController.java
+++ b/src/main/java/com/palangwi/soup/controller/news/NewsController.java
@@ -37,7 +37,7 @@ public class NewsController {
 
     @GetMapping("/{newsId}")
     public ApiResult<NewsDto> getNewsInfo(@AuthenticationPrincipal JwtAuthentication userInfo,
-                                          @PathVariable String newsId) {
+                                          @PathVariable(name = "newsId") String newsId) {
         return success(newsService.getNewsDetailInfo(newsId));
     }
 }

--- a/src/main/java/com/palangwi/soup/dto/keyword/KeywordListResponseDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/KeywordListResponseDto.java
@@ -1,0 +1,11 @@
+package com.palangwi.soup.dto.keyword;
+
+import java.util.List;
+
+public record KeywordListResponseDto(
+        List<KeywordResponseDto> keywordResponseDtos,
+        long totalElements,
+        int totalPages,
+        int currentPages
+) {
+}

--- a/src/main/java/com/palangwi/soup/repository/keyword/KeywordRepository.java
+++ b/src/main/java/com/palangwi/soup/repository/keyword/KeywordRepository.java
@@ -4,6 +4,8 @@ import com.palangwi.soup.domain.keyword.Status;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,6 +25,8 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
     Optional<Keyword> findByNameAndStatus(String name, Status status);
 
     List<Keyword> findByNameContainingIgnoreCaseAndStatus(String name, Status status);
+
+    Page<Keyword> findAllByStatus(Status status, Pageable pageable);
 
     @Query("SELECT k, CASE WHEN uk.subscribed = true THEN true ELSE false END " +
             "FROM Keyword k " +

--- a/src/main/java/com/palangwi/soup/schedule/CollectNewsScheduler.java
+++ b/src/main/java/com/palangwi/soup/schedule/CollectNewsScheduler.java
@@ -19,7 +19,7 @@ public class CollectNewsScheduler {
     private final KeywordRepository keywordRepository;
     private final NewsService newsService;
 
-    @Scheduled(cron = "0 43 17 * * *")
+    @Scheduled(cron = "0 0 7 * * *", zone = "Asia/Seoul")
     private void collectNews() {
         List<Keyword> keywords = keywordRepository.findAll();
         log.info("수집 시작 - 키워드의 갯수 : {}", keywords.size());

--- a/src/main/java/com/palangwi/soup/schedule/MailScheduler.java
+++ b/src/main/java/com/palangwi/soup/schedule/MailScheduler.java
@@ -32,7 +32,7 @@ public class MailScheduler {
     private final UserKeywordRepository userKeywordRepository;
     private final MailService mailService;
 
-    @Scheduled(cron = "0 44 17 * * 1-5", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 8 * * 1-5", zone = "Asia/Seoul")
     public void scheduleDailyNewsLetter() {
         log.info("뉴스 메일 발송 시작");
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordService.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordService.java
@@ -1,5 +1,6 @@
 package com.palangwi.soup.service.keyword;
 
+import com.palangwi.soup.dto.keyword.KeywordListResponseDto;
 import com.palangwi.soup.dto.keyword.KeywordResponseDto;
 import com.palangwi.soup.dto.keyword.RequestKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
@@ -7,6 +8,7 @@ import com.palangwi.soup.dto.keyword.response.KeywordUnsubscribeResponseDto;
 import com.palangwi.soup.dto.keyword.response.RequestKeywordResponseDto;
 import com.palangwi.soup.dto.keyword.response.SearchKeywordsResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
+import org.springframework.data.domain.Pageable;
 
 public interface KeywordService {
 
@@ -25,4 +27,6 @@ public interface KeywordService {
     KeywordUnsubscribeResponseDto unsubscribeKeyword(Long id, Long keywordId);
 
     SearchKeywordsResponseDto searchKeywords(Long userId, String keyword);
+
+    KeywordListResponseDto getKeywordList(Pageable pageable);
 }

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
@@ -4,6 +4,7 @@ import static com.palangwi.soup.utils.KeywordNormalizer.*;
 
 import com.palangwi.soup.domain.keyword.PendingKeywordRequest;
 import com.palangwi.soup.domain.keyword.Status;
+import com.palangwi.soup.dto.keyword.KeywordListResponseDto;
 import com.palangwi.soup.dto.keyword.RequestKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.response.KeywordUnsubscribeResponseDto;
@@ -18,6 +19,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -57,6 +60,15 @@ public class KeywordServiceImpl implements KeywordService {
 
     public void deleteKeyword(Long id) {
 
+    }
+
+    public KeywordListResponseDto getKeywordList(Pageable pageable) {
+        Page<Keyword> keywordsPage = keywordRepository.findAllByStatus(Status.ACTIVE, pageable);
+
+        List<KeywordResponseDto> result = keywordsPage.getContent().stream()
+                .map(KeywordResponseDto::from)
+                .toList();
+        return new KeywordListResponseDto(result,  keywordsPage.getTotalElements(), keywordsPage.getTotalPages(), keywordsPage.getNumber() + 1);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
@@ -64,13 +64,18 @@ public class KeywordServiceImpl implements KeywordService {
 
     }
 
+    @Transactional(readOnly = true)
     public KeywordListResponseDto getKeywordList(Pageable pageable) {
         Page<Keyword> keywordsPage = keywordRepository.findAllByStatus(Status.ACTIVE, pageable);
 
         List<KeywordResponseDto> result = keywordsPage.getContent().stream()
                 .map(KeywordResponseDto::from)
                 .toList();
-        return new KeywordListResponseDto(result,  keywordsPage.getTotalElements(), keywordsPage.getTotalPages(), keywordsPage.getNumber() + 1);
+        return new KeywordListResponseDto(
+                result,
+                keywordsPage.getTotalElements(),
+                keywordsPage.getTotalPages(),
+                keywordsPage.getNumber() + 1);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
```json
{
    "description": {
        "summary": "키워드 목록을 가져오는 기능이 추가되었습니다.",
        "details": "KeywordController에서 키워드 목록을 페이지 네이션하여 가져오는 API가 추가되었으며, 이를 위해 KeywordService와 KeywordRepository가 수정되었습니다. 또한, KeywordListResponseDto가 추가되어 키워드 목록과 관련된 데이터를 반환하도록 구성되었습니다."
    },
    "review": {
        "critical_issues": [],
        "has_issues": false
    }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced paginated keyword list retrieval, allowing users to view keywords with pagination and sorting options.
- **Improvements**
  - Enhanced keyword list responses to include pagination details such as total items, total pages, and current page.
  - Improved scheduling of news collection to explicitly use the Asia/Seoul time zone.
  - Clarified parameter naming in news detail retrieval for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->