### PR TITLE
[fix] OAuth2 로그인 시 email이 username 컬럼에 저장되는 문제 수정

### DIFF
--- a/src/main/java/com/palangwi/soup/domain/user/User.java
+++ b/src/main/java/com/palangwi/soup/domain/user/User.java
@@ -59,8 +59,9 @@ public class User extends BaseEntity {
     private List<PendingKeywordRequest> pendingKeywordRequests = new ArrayList<>();
 
 
-    public static User createFirstLoginUser(String username, String nickname, String providerId) {
+    public static User createFirstLoginUser(String email, String username, String nickname, String providerId) {
         return User.builder()
+                .email(email)
                 .username(username)
                 .nickname(nickname)
                 .providerId(providerId)

--- a/src/main/java/com/palangwi/soup/dto/UserInfo.java
+++ b/src/main/java/com/palangwi/soup/dto/UserInfo.java
@@ -1,4 +1,4 @@
 package com.palangwi.soup.dto;
 
-public record UserInfo(String email, String nickname, String providerId) {
+public record UserInfo(String email, String name , String nickname, String providerId) {
 }

--- a/src/main/java/com/palangwi/soup/security/CustomOAuth2User.java
+++ b/src/main/java/com/palangwi/soup/security/CustomOAuth2User.java
@@ -36,4 +36,8 @@ public class CustomOAuth2User implements OAuth2User {
     public String getProviderId() {
         return userInfo.getRegistrationId();
     }
+
+    public String getEmail() {
+        return userInfo.getEmail();
+    }
 }

--- a/src/main/java/com/palangwi/soup/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/palangwi/soup/security/OAuth2AuthenticationSuccessHandler.java
@@ -50,6 +50,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private UserInfo createUserInfo(Authentication authentication) {
         CustomOAuth2User principal = (CustomOAuth2User) authentication.getPrincipal();
         return new UserInfo(
+                principal.getEmail(),
                 principal.getName(),
                 principal.getNickname(),
                 principal.getProviderId()

--- a/src/main/java/com/palangwi/soup/security/userinfo/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/palangwi/soup/security/userinfo/GoogleOAuth2UserInfo.java
@@ -1,17 +1,20 @@
 package com.palangwi.soup.security.userinfo;
 
 import java.util.Map;
+import lombok.Getter;
 
 public class GoogleOAuth2UserInfo implements OAuth2UserInfo {
 
     private final Map<String, Object> attributes;
     private final String registrationId;
     private final String username;
+    private final String email;
 
     public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
         this.attributes = attributes;
         this.registrationId = "google";
         this.username = (String) attributes.get("email");
+        this.email = (String) attributes.get("email");
     }
 
     @Override
@@ -33,4 +36,10 @@ public class GoogleOAuth2UserInfo implements OAuth2UserInfo {
     public String getNickname() {
         return (String) attributes.get("name");
     }
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+
 }

--- a/src/main/java/com/palangwi/soup/security/userinfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/palangwi/soup/security/userinfo/KakaoOAuth2UserInfo.java
@@ -8,13 +8,16 @@ public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
     private final Map<String, Object> attributes;
     private final String registrationId;
     private final String username;
+// Kakao does not provide email by default, so we use the email from kakao_account
+    private final String email;
 
     public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
         this.attributes = attributes;
         this.registrationId = "kakao";
 
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-        this.username = (String) kakaoAccount.get("email");
+        this.username = (String) kakaoAccount.get("profile_nickname");
+        this.email = (String) kakaoAccount.get("email");
     }
 
     @Override
@@ -36,5 +39,13 @@ public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
     public String getNickname() {
         LinkedHashMap<String, String> properties = (LinkedHashMap) attributes.get("properties");
         return properties.get("nickname");
+    }
+
+    @Override
+    public String getEmail() {
+        if (email == null || email.isEmpty()) {
+            throw new IllegalArgumentException("Email not provided by Kakao account");
+        }
+        return email;
     }
 }

--- a/src/main/java/com/palangwi/soup/security/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/com/palangwi/soup/security/userinfo/OAuth2UserInfo.java
@@ -11,4 +11,6 @@ public interface OAuth2UserInfo {
     String getUsername();
 
     String getNickname();
+
+    String getEmail();
 }

--- a/src/main/java/com/palangwi/soup/service/user/UserService.java
+++ b/src/main/java/com/palangwi/soup/service/user/UserService.java
@@ -34,6 +34,7 @@ public class UserService {
 
         User firstLoginUser = createFirstLoginUser(
                 userInfo.email(),
+                userInfo.name(),
                 userInfo.nickname(),
                 userInfo.providerId()
         );


### PR DESCRIPTION
## 변경 사항 요약
OAuth2 사용자 정보 처리 개선 및 이메일 필드 추가

## 주요 변경 내용
다양한 OAuth2 공급자(Google, Kakao)를 통해 사용자의 이메일 정보를 보다 명확하게 처리할 수 있도록 이메일 필드를 추가 및 수정했습니다. User 클래스의 createFirstLoginUser 메서드에서 이메일이 포함되었으며, UserInfo DTO에 새로운 이메일 필드가 포함되었습니다. 각 OAuth2 사용자 정보 클래스에서 이메일을 가져오는 로직을 명확히 하여, Kakao 사용자의 경우 이메일이 없을 때 예외를 발생시키는 로직도 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added explicit handling and storage of user email and name information during OAuth2 login and user creation.
  - User profiles now include both email and name fields for improved identification.

- **Bug Fixes**
  - Improved separation and validation of username and email fields for OAuth2 providers, ensuring accurate user data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->