### PR TITLE
[refactor] fix cd.yml to not erase volume

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,7 +53,7 @@ jobs:
           script: |
             cd /home/ubuntu
             echo "${{ secrets.DOCKER_COMPOSE_YML }}" | base64 -d > docker-compose.yml
-            sudo docker-compose down -v
+            sudo docker-compose down
             sudo docker-compose up -d
 
       # 헬스 체크 추가


### PR DESCRIPTION
## 변경 사항 요약
Docker Compose를 종료하는 명령어가 변경됨

## 주요 변경 내용
코드 변경사항은 .github/workflows/cd.yml 파일의 56번째 줄에서 'sudo docker-compose down' 명령어의 사용을 추가한 것으로, 이는 현재 실행 중인 Docker Compose 서비스를 중지하고 관련 컨테이너를 정리하는 역할을 합니다. 이로 인해 이전에 실행된 환경을 청소하고 새로운 배포를 준비하는 과정에서의 혼란을 방지할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment process to preserve Docker volumes during container restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->