### PR TITLE
[fix] 내 정보 조회 시 UserKeyword로 인해 발생하는 순환참조 문제 해결

### DIFF
--- a/src/main/java/com/palangwi/soup/dto/user/UserKeywordDto.java
+++ b/src/main/java/com/palangwi/soup/dto/user/UserKeywordDto.java
@@ -1,0 +1,4 @@
+package com.palangwi.soup.dto.user;
+
+public record UserKeywordDto(String keyword) {
+}

--- a/src/main/java/com/palangwi/soup/dto/user/UserResponseDto.java
+++ b/src/main/java/com/palangwi/soup/dto/user/UserResponseDto.java
@@ -2,13 +2,14 @@ package com.palangwi.soup.dto.user;
 
 import com.palangwi.soup.domain.user.Gender;
 import com.palangwi.soup.domain.user.User;
-import com.palangwi.soup.domain.userkeyword.UserKeywords;
+import com.palangwi.soup.domain.userkeyword.UserKeyword;
 import com.palangwi.soup.security.Role;
 import java.time.LocalDate;
+import java.util.List;
 
 public record UserResponseDto(String email, String username, String nickname, Role role, Gender gender,
                               LocalDate birthDate,
-                              String providerId, String profileImageUrl, UserKeywords userKeywords) {
+                              String providerId, String profileImageUrl, List<UserKeywordDto> userKeywords) {
 
     public static UserResponseDto of(User user) {
         return new UserResponseDto(
@@ -20,7 +21,10 @@ public record UserResponseDto(String email, String username, String nickname, Ro
                 user.getBirthDate(),
                 user.getProviderId(),
                 user.getProfileImageUrl(),
-                user.getUserKeywords()
+                user.getUserKeywords().getUserKeywordList().stream()
+                        .filter(UserKeyword::isSubscribed)
+                        .map(uk -> new UserKeywordDto(uk.getKeyword().getName()))
+                        .toList()
         );
     }
 }


### PR DESCRIPTION
## 변경 사항 요약
- UserKeywordDto 레코드를 추가하여 사용자 키워드를 저장하기 위한 구조체를 정의함.
- UserResponseDto에서 사용자 키워드를 필터링하여 UserKeywordDto 리스트로 변환하는 기능을 추가함.

## 주요 변경 내용
- UserKeywordDto.java 파일에 사용자 키워드를 표현하는 record 추가 (파일: UserKeywordDto.java)
- UserResponseDto.java 파일에서 사용자 키워드를 필터링 후 UserKeywordDto 리스트로 매핑하는 로직 수정 (파일: UserResponseDto.java)