### PR TITLE
feat: MySQL to PostgreSQL migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | 영역       | 사용 기술 |
 |------------|-----------|
 | LLM        | Perplexity |
-| 백엔드     | Spring Boot, MySQL, MongoDB, Redis |
+| 백엔드     | Spring Boot, PostgreSQL, MongoDB, Redis |
 | 프론트엔드 | React, Typescript, TailwindCSS |
 | 인프라       | Docker, GitHub Actions |
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,13 +55,16 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'        // Security 테스트
     testImplementation 'org.testcontainers:junit-jupiter'                         // JUnit5 기반 테스트컨테이너
     testImplementation 'org.testcontainers:mongodb'                               // MongoDB 테스트 컨테이너
-    testImplementation 'org.testcontainers:mysql'                                 // MySQL 테스트 컨테이너
+    // testImplementation 'org.testcontainers:mysql'                                 // MySQL 테스트 컨테이너 (제거됨)
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'                  // JUnit 플랫폼 런처
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")               // Mock Web Server
+    testImplementation 'org.testcontainers:postgresql'                            // PostgreSQL Test Container
 
     // 🧱 DB 드라이버
     runtimeOnly 'com.h2database:h2'                                               // 인메모리 DB (개발/테스트용)
-    runtimeOnly 'com.mysql:mysql-connector-j'                                     // MySQL JDBC 드라이버
+    // runtimeOnly 'com.mysql:mysql-connector-j'                                     // MySQL JDBC 드라이버
+    runtimeOnly 'org.postgresql:postgresql'
+
 
     // 🛠 롬복 (컴파일 타임 전용)
     compileOnly 'org.projectlombok:lombok'                                        // 롬복 - 컴파일 타임 전용

--- a/src/test/java/com/palangwi/soup/IntegrationTestSupport.java
+++ b/src/test/java/com/palangwi/soup/IntegrationTestSupport.java
@@ -14,7 +14,7 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest
@@ -41,7 +41,7 @@ public abstract class IntegrationTestSupport {
     @MockitoBean
     protected JavaMailSender javaMailSender;
 
-    static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0")
+    static final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:15")
             .withDatabaseName("testdb")
             .withUsername("testuser")
             .withPassword("testpass");
@@ -49,16 +49,16 @@ public abstract class IntegrationTestSupport {
     static final MongoDBContainer mongoContainer = new MongoDBContainer("mongo:6.0");
 
     static {
-        mysqlContainer.start();
+        postgresContainer.start();
         mongoContainer.start();
     }
 
     @DynamicPropertySource
     static void overrideProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", mysqlContainer::getJdbcUrl);
-        registry.add("spring.datasource.username", mysqlContainer::getUsername);
-        registry.add("spring.datasource.password", mysqlContainer::getPassword);
-        registry.add("spring.datasource.driver-class-name", mysqlContainer::getDriverClassName);
+        registry.add("spring.datasource.url", postgresContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", postgresContainer::getUsername);
+        registry.add("spring.datasource.password", postgresContainer::getPassword);
+        registry.add("spring.datasource.driver-class-name", postgresContainer::getDriverClassName);
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "update");
 
         registry.add("spring.data.mongodb.uri", mongoContainer::getReplicaSetUrl);


### PR DESCRIPTION
## 변경 사항 요약
- MySQL 관련 의존성 제거
- PostgreSQL 관련 의존성 추가 및 컨테이너 설정

## 주요 변경 내용
- build.gradle에서 MySQL 테스트 컨테이너 및 JDBC 드라이버 의존성 제거 (Lines: 58, 65)
- build.gradle에서 PostgreSQL 테스트 컨테이너 및 JDBC 드라이버 의존성 추가 (Lines: 61, 66)
- IntegrationTestSupport.java에서 PostgreSQLContainer 추가 및 설정 (Lines: 17, 44, 52)
- PostgreSQL 연결 속성 추가 (Lines: 58-61)