### PR TITLE
refactor: keyword subscribe management

### DIFF
--- a/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
+++ b/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
@@ -62,7 +62,7 @@ public class KeywordController {
     public ApiResult<SubscribeKeywordResponseDto> subscribeKeyword(
             @AuthenticationPrincipal JwtAuthentication userDetails,
             @Valid @RequestBody SubscribeKeywordRequestDto subscribeKeywordRequestDto) {
-        return success(keywordService.subscribeKeywords(userDetails.id(), subscribeKeywordRequestDto));
+        return success(keywordService.subscribeKeyword(userDetails.id(), subscribeKeywordRequestDto));
     }
 
     @PostMapping("/{keywordId}")

--- a/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
+++ b/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
@@ -69,7 +69,7 @@ public class KeywordController {
     public ApiResult<KeywordUnsubscribeResponseDto> unsubscribeKeyword(
             @AuthenticationPrincipal JwtAuthentication userDetails,
             @PathVariable(name = "subscriptionId") Long subscriptionId) {
-        return success(keywordService.unsubscribeKeyword(userDetails.id(), subscriptionId));
+        return success(keywordService.unsubscribeKeyword(subscriptionId));
     }
 
     @PostMapping("/request")

--- a/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
+++ b/src/main/java/com/palangwi/soup/controller/keyword/KeywordController.java
@@ -58,18 +58,18 @@ public class KeywordController {
 
     @Operation(summary = "키워드 구독", description = "새로운 키워드를 구독합니다.")
     @ApiResponse(responseCode = "200", description = "등록 성공")
-    @PostMapping
+    @PostMapping("/subscriptions")
     public ApiResult<SubscribeKeywordResponseDto> subscribeKeyword(
             @AuthenticationPrincipal JwtAuthentication userDetails,
             @Valid @RequestBody SubscribeKeywordRequestDto subscribeKeywordRequestDto) {
         return success(keywordService.subscribeKeyword(userDetails.id(), subscribeKeywordRequestDto));
     }
 
-    @PostMapping("/{keywordId}")
+    @PostMapping("/subscriptions/{subscriptionId}")
     public ApiResult<KeywordUnsubscribeResponseDto> unsubscribeKeyword(
             @AuthenticationPrincipal JwtAuthentication userDetails,
-            @PathVariable(name = "keywordId") Long keywordId) {
-        return success(keywordService.unsubscribeKeyword(userDetails.id(), keywordId));
+            @PathVariable(name = "subscriptionId") Long subscriptionId) {
+        return success(keywordService.unsubscribeKeyword(userDetails.id(), subscriptionId));
     }
 
     @PostMapping("/request")

--- a/src/main/java/com/palangwi/soup/domain/keyword/PendingKeywordRequest.java
+++ b/src/main/java/com/palangwi/soup/domain/keyword/PendingKeywordRequest.java
@@ -40,9 +40,12 @@ public class PendingKeywordRequest extends BaseEntity {
     }
 
     public static PendingKeywordRequest of(final User user, final Keyword keyword) {
-        return PendingKeywordRequest.builder()
+        PendingKeywordRequest request = PendingKeywordRequest.builder()
                 .user(user)
                 .keyword(keyword)
                 .build();
+        keyword.getPendingKeywordRequests().add(request);
+        return request;
     }
+
 }

--- a/src/main/java/com/palangwi/soup/domain/userkeyword/UserKeyword.java
+++ b/src/main/java/com/palangwi/soup/domain/userkeyword/UserKeyword.java
@@ -49,7 +49,7 @@ public class UserKeyword extends BaseEntity {
         return UserKeyword.builder()
                 .user(user)
                 .keyword(keyword)
-                .subscribed(true)
+                .subscribed(false)
                 .build();
     }
 }

--- a/src/main/java/com/palangwi/soup/domain/userkeyword/UserKeyword.java
+++ b/src/main/java/com/palangwi/soup/domain/userkeyword/UserKeyword.java
@@ -3,20 +3,17 @@ package com.palangwi.soup.domain.userkeyword;
 import com.palangwi.soup.domain.BaseEntity;
 import com.palangwi.soup.domain.keyword.Keyword;
 import com.palangwi.soup.domain.user.User;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_keyword",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "keyword_id"}))
 public class UserKeyword extends BaseEntity {
 
     @Id
@@ -33,6 +30,13 @@ public class UserKeyword extends BaseEntity {
 
     private boolean subscribed;
 
+    @Builder
+    private UserKeyword(User user, Keyword keyword, boolean subscribed) {
+        this.user = user;
+        this.keyword = keyword;
+        this.subscribed = subscribed;
+    }
+
     public void subscribe() {
         this.subscribed = true;
     }
@@ -42,10 +46,10 @@ public class UserKeyword extends BaseEntity {
     }
 
     public static UserKeyword create(User user, Keyword keyword) {
-        UserKeyword userKeyword = new UserKeyword();
-        userKeyword.user = user;
-        userKeyword.keyword = keyword;
-        userKeyword.subscribe();
-        return userKeyword;
+        return UserKeyword.builder()
+                .user(user)
+                .keyword(keyword)
+                .subscribed(true)
+                .build();
     }
 }

--- a/src/main/java/com/palangwi/soup/dto/keyword/MyKeywordDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/MyKeywordDto.java
@@ -18,7 +18,7 @@ public record MyKeywordDto(Long subscriptionId,
         );
     }
 
-    public record KeywordInfo(Long keywordId,
+    private record KeywordInfo(Long keywordId,
                               String keyword,
                               LocalDateTime registeredAt) {}
 }

--- a/src/main/java/com/palangwi/soup/dto/keyword/MyKeywordDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/MyKeywordDto.java
@@ -4,17 +4,21 @@ import com.palangwi.soup.domain.userkeyword.UserKeyword;
 
 import java.time.LocalDateTime;
 
-public record MyKeywordDto(Long userId,
-                           Long keywordId,
-                           String keyword,
-                           String normalizedKeyword,
-                           LocalDateTime registeredDate) {
+public record MyKeywordDto(Long subscriptionId,
+                           KeywordInfo keywordInfo) {
+
     public static MyKeywordDto of(UserKeyword userKeyword) {
         return new MyKeywordDto(
-                userKeyword.getUser().getId(),
-                userKeyword.getKeyword().getId(),
-                userKeyword.getKeyword().getName(),
-                userKeyword.getKeyword().getNormalizedName(),
-                userKeyword.getLastModifiedDate());
+                userKeyword.getId(),
+                new KeywordInfo(
+                        userKeyword.getKeyword().getId(),
+                        userKeyword.getKeyword().getName(),
+                        userKeyword.getLastModifiedDate()
+                )
+        );
     }
+
+    public record KeywordInfo(Long keywordId,
+                              String keyword,
+                              LocalDateTime registeredAt) {}
 }

--- a/src/main/java/com/palangwi/soup/dto/keyword/MyKeywordListResponseDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/MyKeywordListResponseDto.java
@@ -11,12 +11,12 @@ public record MyKeywordListResponseDto(
         int totalPages,
         int currentPage
 ) {
-    public static MyKeywordListResponseDto of(List<MyKeywordDto> myKeywordDtos, Page<UserKeyword> userKeywordPage) {
+    public static MyKeywordListResponseDto of(Page<UserKeyword> userKeywordPage, List<MyKeywordDto> myKeywordDtos) {
         return new MyKeywordListResponseDto(
                 myKeywordDtos,
                 userKeywordPage.getTotalElements(),
                 userKeywordPage.getTotalPages(),
-                userKeywordPage.getNumber()
+                userKeywordPage.getNumber() + 1
         );
     }
 }

--- a/src/main/java/com/palangwi/soup/dto/keyword/SubscribeKeywordRequestDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/SubscribeKeywordRequestDto.java
@@ -1,8 +1,7 @@
 package com.palangwi.soup.dto.keyword;
 
 import jakarta.validation.constraints.NotEmpty;
-import java.util.List;
 
 public record SubscribeKeywordRequestDto(
-        @NotEmpty(message = "키워드는 필수 입력 항목입니다.") List<String> subscribeKeywords) {
+        @NotEmpty(message = "키워드는 필수 입력 항목입니다.") Long keywordId) {
 }

--- a/src/main/java/com/palangwi/soup/dto/keyword/SubscribeKeywordRequestDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/SubscribeKeywordRequestDto.java
@@ -1,7 +1,7 @@
 package com.palangwi.soup.dto.keyword;
 
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 public record SubscribeKeywordRequestDto(
-        @NotEmpty(message = "키워드는 필수 입력 항목입니다.") Long keywordId) {
+        @NotNull(message = "키워드는 필수 입력 항목입니다.")  Long keywordId) {
 }

--- a/src/main/java/com/palangwi/soup/dto/keyword/response/KeywordUnsubscribeResponseDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/response/KeywordUnsubscribeResponseDto.java
@@ -2,7 +2,7 @@ package com.palangwi.soup.dto.keyword.response;
 
 import com.palangwi.soup.domain.userkeyword.UserKeyword;
 
-public record KeywordUnsubscribeResponseDto(Long userId, String keyword) {
+public record KeywordUnsubscribeResponseDto(Long userId, String keywordName) {
     public static KeywordUnsubscribeResponseDto of(UserKeyword userKeyword) {
         return new KeywordUnsubscribeResponseDto(userKeyword.getUser().getId(), userKeyword.getKeyword().getName());
     }

--- a/src/main/java/com/palangwi/soup/dto/keyword/response/SubscribeKeywordResponseDto.java
+++ b/src/main/java/com/palangwi/soup/dto/keyword/response/SubscribeKeywordResponseDto.java
@@ -1,9 +1,7 @@
 package com.palangwi.soup.dto.keyword.response;
 
-import java.util.List;
-
-public record SubscribeKeywordResponseDto(List<String> registeredKeywords) {
-    public static SubscribeKeywordResponseDto of(List<String> registeredKeywords) {
-        return new SubscribeKeywordResponseDto(registeredKeywords);
+public record SubscribeKeywordResponseDto(Long keywordId, String keywordName) {
+    public static SubscribeKeywordResponseDto of(Long keywordId, String keywordName) {
+        return new SubscribeKeywordResponseDto(keywordId, keywordName);
     }
 }

--- a/src/main/java/com/palangwi/soup/exception/keyword/AlreadySubscribedKeywordException.java
+++ b/src/main/java/com/palangwi/soup/exception/keyword/AlreadySubscribedKeywordException.java
@@ -1,15 +1,13 @@
 package com.palangwi.soup.exception.keyword;
 
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
 
 import com.palangwi.soup.exception.BaseCustomException;
 
 public class AlreadySubscribedKeywordException extends BaseCustomException {
-    private final List<String> alreadySubscribedKeywords;
+    private final String alreadySubscribedKeywords;
 
-    public AlreadySubscribedKeywordException(List<String> alreadySubscribedKeywords) {
+    public AlreadySubscribedKeywordException(String alreadySubscribedKeywords) {
         this.alreadySubscribedKeywords = alreadySubscribedKeywords;
     }
 

--- a/src/main/java/com/palangwi/soup/exception/keyword/KeywordExceptionMessage.java
+++ b/src/main/java/com/palangwi/soup/exception/keyword/KeywordExceptionMessage.java
@@ -11,7 +11,7 @@ public enum KeywordExceptionMessage {
     ALREADY_REJECTED_KEYWORD("이미 등록이 거절된 키워드입니다.", HttpStatus.BAD_REQUEST),
     KEYWORD_INVALID_STATUS_EXCEPTION("키워드의 상태가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
     KEYWORD_ALREADY_REQUESTED("이미 등록 요청한 키워드입니다.", HttpStatus.BAD_REQUEST),
-    KEYWORD_ALREADY_EXIST("이미 등록된 키워드입니다.", HttpStatus.BAD_REQUEST),
+    KEYWORD_ALREADY_EXIST("이미 등록된 키워드입니다.", HttpStatus.CONFLICT),
     KEYWORD_NOT_EXIST("존재하지 않는 키워드입니다.", HttpStatus.BAD_REQUEST),
     SUBSCRIBED_KEYWORD_LIMIT_EXCEEDED("키워드는 최대 10개까지 구독할 수 있습니다.",  HttpStatus.BAD_REQUEST),;
 

--- a/src/main/java/com/palangwi/soup/repository/admin/keyword/AdminKeywordRepository.java
+++ b/src/main/java/com/palangwi/soup/repository/admin/keyword/AdminKeywordRepository.java
@@ -1,5 +1,6 @@
 package com.palangwi.soup.repository.admin.keyword;
 
+import com.palangwi.soup.domain.keyword.Keyword;
 import com.palangwi.soup.domain.keyword.PendingKeywordRequest;
 import com.palangwi.soup.domain.keyword.Status;
 import org.springframework.data.domain.Page;
@@ -15,4 +16,5 @@ public interface AdminKeywordRepository extends JpaRepository<PendingKeywordRequ
     Page<PendingKeywordRequest> findByStatus(@Param("status") Status status, Pageable pageable);
 
     void deleteByKeywordId(Long id);
+    void deleteAllByKeyword(Keyword keyword);
 }

--- a/src/main/java/com/palangwi/soup/repository/userkeyword/UserKeywordRepository.java
+++ b/src/main/java/com/palangwi/soup/repository/userkeyword/UserKeywordRepository.java
@@ -44,4 +44,6 @@ public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> 
             @Param("userId") Long userId,
             @Param("keywordIds") List<Long> keywordIds
     );
+
+    boolean existsByUser_IdAndKeyword_Id(Long userId, Long keywordId);
 }

--- a/src/main/java/com/palangwi/soup/service/admin/keyword/AdminKeywordRequestServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/admin/keyword/AdminKeywordRequestServiceImpl.java
@@ -61,26 +61,23 @@ public class AdminKeywordRequestServiceImpl implements AdminKeywordRequestServic
                 .orElseThrow(KeywordNotFoundException::new);
 
         Keyword keyword = request.getKeyword();
+        keyword.approve(request.getUser());
 
-        User firstRequestUser = getFirstRequestUser(keyword);
-
-        keyword.approve(firstRequestUser);
-
-        List<UserKeyword> newUserKeywords = keyword.getPendingKeywordRequests().stream()
+        List<UserKeyword> userKeywords = keyword.getPendingKeywordRequests().stream()
                 .map(PendingKeywordRequest::getUser)
-                .filter(user -> !user.getUserKeywords().isAlreadySubscribed(keyword))
+                .filter(user -> !userKeywordRepository.existsByUser_IdAndKeyword_Id(user.getId(), keyword.getId()))
                 .map(user -> {
-                    UserKeyword userKeyword = UserKeyword.create(user, keyword);
-                    userKeyword.subscribe();
-                    return userKeyword;
+                    UserKeyword uk = UserKeyword.create(user, keyword);
+                    uk.subscribe();
+                    return uk;
                 })
                 .toList();
 
-        userKeywordRepository.saveAll(newUserKeywords);
+        userKeywordRepository.saveAll(userKeywords);
 
-        adminKeywordRepository.deleteByKeywordId(keyword.getId());
+        adminKeywordRepository.deleteAllByKeyword(keyword);
 
-        return ApproveKeywordResponseDto.of(keyword.getName(), newUserKeywords.size());
+        return ApproveKeywordResponseDto.of(keyword.getName(), userKeywords.size());
     }
 
     private User getFirstRequestUser(Keyword keyword) {

--- a/src/main/java/com/palangwi/soup/service/admin/keyword/AdminKeywordService.java
+++ b/src/main/java/com/palangwi/soup/service/admin/keyword/AdminKeywordService.java
@@ -1,8 +1,6 @@
 package com.palangwi.soup.service.admin.keyword;
 
 import com.palangwi.soup.dto.admin.keyword.AddKeywordResponseDto;
-import com.palangwi.soup.dto.admin.keyword.ApproveKeywordResponseDto;
-import com.palangwi.soup.dto.admin.keyword.RejectKeywordResponseDto;
 import com.palangwi.soup.dto.admin.keyword.RemoveKeywordResponseDto;
 import com.palangwi.soup.dto.keyword.KeywordListResponseDto;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordService.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordService.java
@@ -25,7 +25,7 @@ public interface KeywordService {
 
     RequestKeywordResponseDto requestKeywords(Long userId, RequestKeywordRequestDto requestKeywordRequestDto);
 
-    KeywordUnsubscribeResponseDto unsubscribeKeyword(Long id, Long keywordId);
+    KeywordUnsubscribeResponseDto unsubscribeKeyword(Long subscriptionId);
 
     MyKeywordListResponseDto getMyKeywords(Long userId, Pageable pageable);
 

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordService.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordService.java
@@ -19,7 +19,7 @@ public interface KeywordService {
 
     KeywordResponseDto updateKeywordName(Long id, String name);
 
-    SubscribeKeywordResponseDto subscribeKeywords(Long userId, SubscribeKeywordRequestDto subscribeKeywordRequestDto);
+    SubscribeKeywordResponseDto subscribeKeyword(Long userId, SubscribeKeywordRequestDto subscribeKeywordRequestDto);
 
     void deleteKeyword(Long id);
 

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
@@ -148,25 +148,43 @@ public class KeywordServiceImpl implements KeywordService {
     @Transactional
     public SubscribeKeywordResponseDto subscribeKeyword(Long userId, SubscribeKeywordRequestDto dto) {
         User user = findUserById(userId);
+        validateSubscriptionLimit(userId);
 
-        if (userKeywordRepository.countSubscribedKeywordsByUserId(userId) >= MAXIMUM_KEYWORD_COUNT) {
-            throw new SubscribedKeywordLimitExceededException();
-        }
-
-        UserKeyword userKeyword = userKeywordRepository
-                .findSubscribedByUserIdAndKeywordId(userId, dto.keywordId())
-                .orElseGet(() -> {
-                    Keyword keyword = keywordRepository.findById(dto.keywordId())
-                            .orElseThrow(KeywordNotFoundException::new);
-                    return UserKeyword.create(user, keyword);
-                });
+        UserKeyword userKeyword = findOrCreateUserKeyword(user, dto.keywordId());
+        validateNotAlreadySubscribed(userKeyword);
 
         userKeyword.subscribe();
         userKeywordRepository.save(userKeyword);
 
+        return toResponseDto(userKeyword);
+    }
+
+    private void validateSubscriptionLimit(Long userId) {
+        if (userKeywordRepository.countSubscribedKeywordsByUserId(userId) >= MAXIMUM_KEYWORD_COUNT) {
+            throw new SubscribedKeywordLimitExceededException();
+        }
+    }
+
+    private UserKeyword findOrCreateUserKeyword(User user, Long keywordId) {
+        return userKeywordRepository.findSubscribedByUserIdAndKeywordId(user.getId(), keywordId)
+                .orElseGet(() -> {
+                    Keyword keyword = keywordRepository.findById(keywordId)
+                            .orElseThrow(KeywordNotFoundException::new);
+                    return UserKeyword.create(user, keyword);
+                });
+    }
+
+    private void validateNotAlreadySubscribed(UserKeyword userKeyword) {
+        if (userKeyword.isSubscribed()) {
+            throw new AlreadySubscribedKeywordException(userKeyword.getKeyword().getName());
+        }
+    }
+
+    private SubscribeKeywordResponseDto toResponseDto(UserKeyword userKeyword) {
         Keyword keyword = userKeyword.getKeyword();
         return SubscribeKeywordResponseDto.of(keyword.getId(), keyword.getName());
     }
+
 
     private void initPendingKeywordRequest(User user, Keyword keyword) {
         if (pendingKeywordRequestRepository.existsByUserAndKeyword(user, keyword)) {

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
@@ -28,6 +28,7 @@ import com.palangwi.soup.repository.userkeyword.UserKeywordRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -147,23 +148,31 @@ public class KeywordServiceImpl implements KeywordService {
     }
 
     @Transactional
-    public SubscribeKeywordResponseDto subscribeKeywords(Long userId,
-            SubscribeKeywordRequestDto subscribeKeywordRequestDto) {
+    public SubscribeKeywordResponseDto subscribeKeyword(Long userId,
+                                                        SubscribeKeywordRequestDto dto) {
         User user = findUserById(userId);
 
-        if (userKeywordRepository.countSubscribedKeywordsByUserId(userId) > MAXIMUM_KEYWORD_COUNT) {
+        if (userKeywordRepository.countSubscribedKeywordsByUserId(userId) >= MAXIMUM_KEYWORD_COUNT) {
             throw new SubscribedKeywordLimitExceededException();
         }
 
-        List<String> keywordNames = subscribeKeywordRequestDto.subscribeKeywords();
+        Keyword keyword = userKeywordRepository
+                .findSubscribedByUserIdAndKeywordId(userId, dto.keywordId())
+                .map(uk -> {
+                    uk.subscribe();
+                    return uk.getKeyword();
+                })
+                .orElseGet(() -> keywordRepository.findById(dto.keywordId())
+                        .orElseThrow(KeywordNotFoundException::new));
 
-        List<UserKeyword> userKeywords = createUserKeywords(user, keywordNames);
-        userKeywordRepository.saveAll(userKeywords);
+        UserKeyword userKeyword = userKeywordRepository
+                .findSubscribedByUserIdAndKeywordId(userId, dto.keywordId())
+                .orElseGet(() -> UserKeyword.create(user, keyword));
 
-        return SubscribeKeywordResponseDto.of(
-                userKeywords.stream()
-                        .map(userKeyword -> userKeyword.getKeyword().getName())
-                        .toList());
+        userKeyword.subscribe();
+        userKeywordRepository.save(userKeyword);
+
+        return SubscribeKeywordResponseDto.of(keyword.getId(), keyword.getName());
     }
 
     private void initPendingKeywordRequest(User user, Keyword keyword) {
@@ -179,53 +188,31 @@ public class KeywordServiceImpl implements KeywordService {
         return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
     }
-
-    private List<UserKeyword> createUserKeywords(User user, List<String> keywordNames) {
-        Map<String, Keyword> keywordMap = validateKeywordNames(user, keywordNames);
-        return filterAndBuildUserKeywords(user, keywordNames, keywordMap);
-    }
-
-    private Map<String, Keyword> validateKeywordNames(User user, List<String> keywordNames) {
-        List<Keyword> existingKeywords = keywordRepository.findAllByNameIn(keywordNames);
-        Map<String, Keyword> keywordMap = existingKeywords.stream()
-                .collect(Collectors.toMap(Keyword::getName, k -> k));
-
-        List<String> notFound = keywordNames.stream()
-                .filter(name -> !keywordMap.containsKey(name))
-                .toList();
-
-        if (!notFound.isEmpty()) {
-            log.warn("{} 사용자가 요청한 다음 키워드들을 찾을 수 없습니다: {}", user.getId(), notFound);
-            throw new KeywordNotExistException(notFound);
-        }
-
-        return keywordMap;
-    }
-
-    private List<UserKeyword> filterAndBuildUserKeywords(User user, List<String> keywordNames,
-            Map<String, Keyword> keywordMap) {
-        List<UserKeyword> result = new ArrayList<>();
-        List<String> alreadySubscribed = new ArrayList<>();
-
-        for (String name : keywordNames) {
-            Keyword keyword = keywordMap.get(name);
-
-            user.getUserKeywords().findByKeyword(keyword).ifPresentOrElse(
-                    userKeyword -> {
-                        if (userKeyword.isSubscribed()) {
-                            alreadySubscribed.add(name);
-                        } else {
-                            userKeyword.subscribe();
-                            result.add(userKeyword);
-                        }
-                    },
-                    () -> result.add(UserKeyword.create(user, keyword)));
-        }
-
-        if (!alreadySubscribed.isEmpty()) {
-            throw new AlreadySubscribedKeywordException(alreadySubscribed);
-        }
-
-        return result;
-    }
+//
+//    private List<UserKeyword> filterAndBuildUserKeywords(User user, List<String> keywordNames,
+//            Map<String, Keyword> keywordMap) {
+//        List<UserKeyword> result = new ArrayList<>();
+//        List<String> alreadySubscribed = new ArrayList<>();
+//
+//        for (String name : keywordNames) {
+//            Keyword keyword = keywordMap.get(name);
+//
+//            user.getUserKeywords().findByKeyword(keyword).ifPresentOrElse(
+//                    userKeyword -> {
+//                        if (userKeyword.isSubscribed()) {
+//                            alreadySubscribed.add(name);
+//                        } else {
+//                            userKeyword.subscribe();
+//                            result.add(userKeyword);
+//                        }
+//                    },
+//                    () -> result.add(UserKeyword.create(user, keyword)));
+//        }
+//
+//        if (!alreadySubscribed.isEmpty()) {
+//            throw new AlreadySubscribedKeywordException(alreadySubscribed);
+//        }
+//
+//        return result;
+//    }
 }

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
@@ -148,30 +148,25 @@ public class KeywordServiceImpl implements KeywordService {
     }
 
     @Transactional
-    public SubscribeKeywordResponseDto subscribeKeyword(Long userId,
-                                                        SubscribeKeywordRequestDto dto) {
+    public SubscribeKeywordResponseDto subscribeKeyword(Long userId, SubscribeKeywordRequestDto dto) {
         User user = findUserById(userId);
 
         if (userKeywordRepository.countSubscribedKeywordsByUserId(userId) >= MAXIMUM_KEYWORD_COUNT) {
             throw new SubscribedKeywordLimitExceededException();
         }
 
-        Keyword keyword = userKeywordRepository
-                .findSubscribedByUserIdAndKeywordId(userId, dto.keywordId())
-                .map(uk -> {
-                    uk.subscribe();
-                    return uk.getKeyword();
-                })
-                .orElseGet(() -> keywordRepository.findById(dto.keywordId())
-                        .orElseThrow(KeywordNotFoundException::new));
-
         UserKeyword userKeyword = userKeywordRepository
                 .findSubscribedByUserIdAndKeywordId(userId, dto.keywordId())
-                .orElseGet(() -> UserKeyword.create(user, keyword));
+                .orElseGet(() -> {
+                    Keyword keyword = keywordRepository.findById(dto.keywordId())
+                            .orElseThrow(KeywordNotFoundException::new);
+                    return UserKeyword.create(user, keyword);
+                });
 
         userKeyword.subscribe();
         userKeywordRepository.save(userKeyword);
 
+        Keyword keyword = userKeyword.getKeyword();
         return SubscribeKeywordResponseDto.of(keyword.getId(), keyword.getName());
     }
 
@@ -188,31 +183,4 @@ public class KeywordServiceImpl implements KeywordService {
         return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
     }
-//
-//    private List<UserKeyword> filterAndBuildUserKeywords(User user, List<String> keywordNames,
-//            Map<String, Keyword> keywordMap) {
-//        List<UserKeyword> result = new ArrayList<>();
-//        List<String> alreadySubscribed = new ArrayList<>();
-//
-//        for (String name : keywordNames) {
-//            Keyword keyword = keywordMap.get(name);
-//
-//            user.getUserKeywords().findByKeyword(keyword).ifPresentOrElse(
-//                    userKeyword -> {
-//                        if (userKeyword.isSubscribed()) {
-//                            alreadySubscribed.add(name);
-//                        } else {
-//                            userKeyword.subscribe();
-//                            result.add(userKeyword);
-//                        }
-//                    },
-//                    () -> result.add(UserKeyword.create(user, keyword)));
-//        }
-//
-//        if (!alreadySubscribed.isEmpty()) {
-//            throw new AlreadySubscribedKeywordException(alreadySubscribed);
-//        }
-//
-//        return result;
-//    }
 }

--- a/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/service/keyword/KeywordServiceImpl.java
@@ -115,8 +115,8 @@ public class KeywordServiceImpl implements KeywordService {
     }
 
     @Transactional
-    public KeywordUnsubscribeResponseDto unsubscribeKeyword(Long userId, Long keywordId) {
-        UserKeyword userKeyword = userKeywordRepository.findSubscribedByUserIdAndKeywordId(userId, keywordId)
+    public KeywordUnsubscribeResponseDto unsubscribeKeyword(Long subscriptionId) {
+        UserKeyword userKeyword = userKeywordRepository.findById(subscriptionId)
                 .orElseThrow(NotSubscribedException::new);
         userKeyword.unsubscribe();
         return KeywordUnsubscribeResponseDto.of(userKeyword);
@@ -126,11 +126,9 @@ public class KeywordServiceImpl implements KeywordService {
     public MyKeywordListResponseDto getMyKeywords(Long userId, Pageable pageable) {
         Page<UserKeyword> userKeywords = userKeywordRepository.findAllByUser_IdAndSubscribedTrue(userId, pageable);
 
-        List<MyKeywordDto> userKeywordList = userKeywords.getContent().stream()
-                .map(MyKeywordDto::of)
-                .toList();
+        List<MyKeywordDto> userKeywordList = userKeywords.map(MyKeywordDto::of).getContent();
 
-        return MyKeywordListResponseDto.of(userKeywordList, userKeywords);
+        return MyKeywordListResponseDto.of(userKeywords, userKeywordList);
     }
 
     private Keyword findOrCreateKeyword(String requestedKeyword, User user) {

--- a/src/test/java/com/palangwi/soup/controller/keyword/KeywordControllerTest.java
+++ b/src/test/java/com/palangwi/soup/controller/keyword/KeywordControllerTest.java
@@ -77,10 +77,10 @@ class KeywordControllerTest extends IntegrationTestSupport {
     @WithMockJwtAuthentication(id = 1L)
     void registerKeyword_success() throws Exception {
         // given
-        SubscribeKeywordRequestDto request = new SubscribeKeywordRequestDto(Arrays.asList("키워드1", "키워드2"));
-        SubscribeKeywordResponseDto response = new SubscribeKeywordResponseDto(Arrays.asList("키워드1", "키워드2"));
+        SubscribeKeywordRequestDto request = new SubscribeKeywordRequestDto(1L);
+        SubscribeKeywordResponseDto response = new SubscribeKeywordResponseDto(1L, "AI");
 
-        given(keywordService.subscribeKeywords(1L, request))
+        given(keywordService.subscribeKeyword(1L, request))
                 .willReturn(response);
 
         // when // then
@@ -93,7 +93,7 @@ class KeywordControllerTest extends IntegrationTestSupport {
                 .andExpect(jsonPath("$.data.registeredKeywords[0]").value("키워드1"))
                 .andExpect(jsonPath("$.data.registeredKeywords[1]").value("키워드2"));
 
-        verify(keywordService).subscribeKeywords(1L, request);
+        verify(keywordService).subscribeKeyword(1L, request);
     }
 
     @Test
@@ -101,8 +101,8 @@ class KeywordControllerTest extends IntegrationTestSupport {
     @WithMockJwtAuthentication(id = 1L)
     void registerKeyword_alreadySubscribed() throws Exception {
         // given
-        SubscribeKeywordRequestDto request = new SubscribeKeywordRequestDto(Arrays.asList("키워드1"));
-        given(keywordService.subscribeKeywords(1L, request))
+        SubscribeKeywordRequestDto request = new SubscribeKeywordRequestDto(1L);
+        given(keywordService.subscribeKeyword(1L, request))
                 .willThrow(new AlreadySubscribedKeywordException(List.of("키워드1")));
 
         // when // then

--- a/src/test/java/com/palangwi/soup/controller/keyword/KeywordControllerTest.java
+++ b/src/test/java/com/palangwi/soup/controller/keyword/KeywordControllerTest.java
@@ -84,14 +84,14 @@ class KeywordControllerTest extends IntegrationTestSupport {
                 .willReturn(response);
 
         // when // then
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/keywords")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/keywords/subscriptions")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.registeredKeywords[0]").value("키워드1"))
-                .andExpect(jsonPath("$.data.registeredKeywords[1]").value("키워드2"));
+                .andExpect(jsonPath("$.data.keywordId").value(1L))
+                .andExpect(jsonPath("$.data.keywordName").value("AI"));
 
         verify(keywordService).subscribeKeyword(1L, request);
     }
@@ -103,15 +103,15 @@ class KeywordControllerTest extends IntegrationTestSupport {
         // given
         SubscribeKeywordRequestDto request = new SubscribeKeywordRequestDto(1L);
         given(keywordService.subscribeKeyword(1L, request))
-                .willThrow(new AlreadySubscribedKeywordException(List.of("키워드1")));
+                .willThrow(new AlreadySubscribedKeywordException("AI"));
 
         // when // then
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/keywords")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/keywords/subscriptions")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.message").value("이미 등록된 키워드입니다.: 키워드1"));
+                .andExpect(jsonPath("$.error.message").value("이미 등록된 키워드입니다.: AI"));
     }
 }

--- a/src/test/java/com/palangwi/soup/controller/keyword/KeywordControllerTest.java
+++ b/src/test/java/com/palangwi/soup/controller/keyword/KeywordControllerTest.java
@@ -110,7 +110,7 @@ class KeywordControllerTest extends IntegrationTestSupport {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andExpect(status().isConflict())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.message").value("이미 등록된 키워드입니다.: AI"));
     }

--- a/src/test/java/com/palangwi/soup/service/keyword/KeywordServiceTest.java
+++ b/src/test/java/com/palangwi/soup/service/keyword/KeywordServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palangwi.soup.IntegrationTestSupport;
 import com.palangwi.soup.domain.keyword.Keyword;
+import com.palangwi.soup.domain.keyword.PendingKeywordRequest;
 import com.palangwi.soup.domain.keyword.Source;
 import com.palangwi.soup.domain.user.Gender;
 import com.palangwi.soup.domain.user.User;
@@ -13,10 +14,13 @@ import com.palangwi.soup.dto.keyword.SubscribeKeywordRequestDto;
 import com.palangwi.soup.dto.keyword.response.SearchKeywordDto;
 import com.palangwi.soup.dto.keyword.response.SearchKeywordsResponseDto;
 import com.palangwi.soup.dto.keyword.response.SubscribeKeywordResponseDto;
+import com.palangwi.soup.repository.admin.keyword.AdminKeywordRepository;
 import com.palangwi.soup.repository.keyword.KeywordRepository;
 import com.palangwi.soup.repository.user.UserRepository;
 import com.palangwi.soup.repository.userkeyword.UserKeywordRepository;
 import com.palangwi.soup.security.Role;
+import com.palangwi.soup.service.admin.keyword.AdminKeywordRequestService;
+import com.palangwi.soup.service.admin.keyword.AdminKeywordService;
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -49,6 +53,11 @@ class KeywordServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private AdminKeywordRequestService adminKeywordRequestService;
+    @Autowired
+    private AdminKeywordRepository adminKeywordRepository;
 
     @BeforeEach
     void setUp() {
@@ -114,26 +123,27 @@ class KeywordServiceTest extends IntegrationTestSupport {
         Keyword keyword3 = Keyword.of("파이썬", "python", Source.USER_REQUEST, user);
         keywordRepository.saveAll(Arrays.asList(keyword1, keyword2, keyword3));
 
-        userKeywordRepository.saveAll(List.of(UserKeyword.create(user, keyword1)));
+        PendingKeywordRequest request = PendingKeywordRequest.of(user, keyword1);
+        adminKeywordRepository.save(request);
+        Long requestId = request.getId();
 
-        String searchKeyword = "자바";
-        keyword1.approve(user);
-        keyword2.approve(user);
+        adminKeywordRequestService.approveKeyword(requestId);
+
         Pageable pageable = PageRequest.of(0, 20);
+
         // when
-        SearchKeywordsResponseDto response = keywordService.searchKeywords(user.getId(), searchKeyword, pageable);
+        SearchKeywordsResponseDto response = keywordService.searchKeywords(user.getId(), "자바", pageable);
 
         // then
-        assertThat(response.keywords()).hasSize(2);
+        assertThat(response.keywords()).hasSize(1);
         assertThat(response.keywords().stream().map(SearchKeywordDto::name).toList())
-                .containsExactly("자바", "자바스크립트");
+                .containsExactly("자바");
+
         assertThat(response.keywords().get(0).name()).isEqualTo("자바");
         assertThat(response.keywords().get(0).normalizedName()).isEqualTo("java");
         assertThat(response.keywords().get(0).isSubscribed()).isTrue();
-        assertThat(response.keywords().get(1).name()).isEqualTo("자바스크립트");
-        assertThat(response.keywords().get(1).normalizedName()).isEqualTo("javascript");
-        assertThat(response.keywords().get(1).isSubscribed()).isFalse();
-        assertThat(response.totalElements()).isEqualTo(2);
+
+        assertThat(response.totalElements()).isEqualTo(1);
         assertThat(response.totalPages()).isEqualTo(1);
         assertThat(response.currentPage()).isEqualTo(1);
     }

--- a/src/test/java/com/palangwi/soup/service/keyword/KeywordServiceTest.java
+++ b/src/test/java/com/palangwi/soup/service/keyword/KeywordServiceTest.java
@@ -86,17 +86,17 @@ class KeywordServiceTest extends IntegrationTestSupport {
         Keyword keyword2 = Keyword.of("키워드2", "키워드2", Source.USER_REQUEST, user);
         keywordRepository.saveAll(Arrays.asList(keyword1, keyword2));
 
-        List<String> keywords = Arrays.asList("키워드1", "키워드2");
+        Long keywordId = keyword1.getId();
 
-        SubscribeKeywordRequestDto requestDto = new SubscribeKeywordRequestDto(keywords);
+        SubscribeKeywordRequestDto requestDto = new SubscribeKeywordRequestDto(keywordId);
 
         // when
         SubscribeKeywordResponseDto result = keywordService.subscribeKeyword(user.getId(), requestDto);
 
         // then
-        assertThat(result.registeredKeywords()).hasSize(2);
-        assertThat(keywordRepository.findAll()).hasSize(2);
-        assertThat(userKeywordRepository.findAll()).hasSize(2);
+        assertThat(result.keywordId()).isEqualTo(keywordId);
+        assertThat(keywordRepository.existsById(keywordId)).isTrue();
+        assertThat(userKeywordRepository.findAll()).hasSize(1);
     }
 
     @Test

--- a/src/test/java/com/palangwi/soup/service/keyword/KeywordServiceTest.java
+++ b/src/test/java/com/palangwi/soup/service/keyword/KeywordServiceTest.java
@@ -59,6 +59,8 @@ class KeywordServiceTest extends IntegrationTestSupport {
 
     @AfterEach
     void tearDown() {
+        userKeywordRepository.deleteAll();
+        keywordRepository.deleteAll();
         userRepository.deleteAll();
     }
 
@@ -81,9 +83,12 @@ class KeywordServiceTest extends IntegrationTestSupport {
     @Test
     void registerKeyword_정상등록() {
         // given
-        User user = createUser("테스트 닉네임");
-        Keyword keyword1 = Keyword.of("키워드1", "키워드1", Source.USER_REQUEST, user);
-        Keyword keyword2 = Keyword.of("키워드2", "키워드2", Source.USER_REQUEST, user);
+        User user1 = createUser("키워드를 등록한 사용자");
+        Keyword keyword1 = Keyword.of("키워드1", "키워드1", Source.USER_REQUEST, user1);
+        Keyword keyword2 = Keyword.of("키워드2", "키워드2", Source.USER_REQUEST, user1);
+
+        User user2 = createUser("키워드를 등록할 사용자");
+
         keywordRepository.saveAll(Arrays.asList(keyword1, keyword2));
 
         Long keywordId = keyword1.getId();
@@ -91,7 +96,7 @@ class KeywordServiceTest extends IntegrationTestSupport {
         SubscribeKeywordRequestDto requestDto = new SubscribeKeywordRequestDto(keywordId);
 
         // when
-        SubscribeKeywordResponseDto result = keywordService.subscribeKeyword(user.getId(), requestDto);
+        SubscribeKeywordResponseDto result = keywordService.subscribeKeyword(user2.getId(), requestDto);
 
         // then
         assertThat(result.keywordId()).isEqualTo(keywordId);

--- a/src/test/java/com/palangwi/soup/service/keyword/KeywordServiceTest.java
+++ b/src/test/java/com/palangwi/soup/service/keyword/KeywordServiceTest.java
@@ -91,7 +91,7 @@ class KeywordServiceTest extends IntegrationTestSupport {
         SubscribeKeywordRequestDto requestDto = new SubscribeKeywordRequestDto(keywords);
 
         // when
-        SubscribeKeywordResponseDto result = keywordService.subscribeKeywords(user.getId(), requestDto);
+        SubscribeKeywordResponseDto result = keywordService.subscribeKeyword(user.getId(), requestDto);
 
         // then
         assertThat(result.registeredKeywords()).hasSize(2);


### PR DESCRIPTION
## 변경 사항 요약
- 키워드 구독 및 구독 취소 기능 추가
- 키워드 관련 DTO 및 요청/응답 형식 개선

## 주요 변경 내용
- KeywordController에 키워드 구독 및 구독 취소 API 추가 (파일: KeywordController.java)
- PendingKeywordRequest에서 새로운 키워드 요청 처리 추가 (파일: PendingKeywordRequest.java)
- UserKeyword에서 빌더 패턴을 통한 객체 생성 방식 변경 (파일: UserKeyword.java)
- MyKeywordDto 및 MyKeywordListResponseDto에 적절한 데이터 변환 추가 (파일: MyKeywordDto.java, MyKeywordListResponseDto.java)
- SubscribeKeywordRequestDto에 필수 입력 검증 추가 (파일: SubscribeKeywordRequestDto.java)
- KeywordUnsubscribeResponseDto 및 SubscribeKeywordResponseDto 추가 (파일: KeywordUnsubscribeResponseDto.java, SubscribeKeywordResponseDto.java)
- AlreadySubscribedKeywordException과 KeywordExceptionMessage 업데이트 (파일: AlreadySubscribedKeywordException.java, KeywordExceptionMessage.java)
- AdminKeywordRequestServiceImpl.updateKeywordLogic에서 키워드 승인 기능 개선 (파일: AdminKeywordRequestServiceImpl.java)
- 서비스 및 레포지토리에서 사용자 키워드 구독 여부 확인 추가 (파일: UserKeywordRepository.java, KeywordService.java, KeywordServiceImpl.java)