### PR TITLE
refactor: NoSQL에 연관된 키워드 필드 추가

### DIFF
--- a/src/main/java/com/palangwi/soup/news/domain/News.java
+++ b/src/main/java/com/palangwi/soup/news/domain/News.java
@@ -28,7 +28,7 @@ public class News extends BaseEntity {
 
     private List<Article> articles;
 
-    private List<String> related_keyword;
+    private List<String> relatedKeywords;
 
     private int tokens;
 

--- a/src/main/java/com/palangwi/soup/news/domain/News.java
+++ b/src/main/java/com/palangwi/soup/news/domain/News.java
@@ -28,7 +28,7 @@ public class News extends BaseEntity {
 
     private List<Article> articles;
 
-    private String[] related_keyword;
+    private List<String> related_keyword;
 
     private int tokens;
 

--- a/src/main/java/com/palangwi/soup/news/domain/News.java
+++ b/src/main/java/com/palangwi/soup/news/domain/News.java
@@ -28,6 +28,8 @@ public class News extends BaseEntity {
 
     private List<Article> articles;
 
+    private String[] related_keyword;
+
     private int tokens;
 
     public News(Long keywordId, String keywordName, Summary summary, List<Article> articles, int tokens) {

--- a/src/main/java/com/palangwi/soup/news/dto/NewsDto.java
+++ b/src/main/java/com/palangwi/soup/news/dto/NewsDto.java
@@ -24,7 +24,7 @@ public record NewsDto(Long keywordId,
                                 article.getSummary()
                         ))
                         .toList(),
-                news.getRelated_keyword(),
+                news.getRelatedKeywords(),
                 news.getCreatedDate());
     }
 }

--- a/src/main/java/com/palangwi/soup/news/dto/NewsDto.java
+++ b/src/main/java/com/palangwi/soup/news/dto/NewsDto.java
@@ -24,7 +24,7 @@ public record NewsDto(Long keywordId,
                                 article.getSummary()
                         ))
                         .toList(),
-                Arrays.asList(news.getRelated_keyword()),
+                news.getRelated_keyword(),
                 news.getCreatedDate());
     }
 }

--- a/src/main/java/com/palangwi/soup/news/dto/NewsDto.java
+++ b/src/main/java/com/palangwi/soup/news/dto/NewsDto.java
@@ -3,9 +3,16 @@ package com.palangwi.soup.news.dto;
 import com.palangwi.soup.news.domain.News;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 
-public record NewsDto(Long keywordId, String keywordName, String longSummary, List<ArticleDto> articles, LocalDateTime createdDate) {
+public record NewsDto(Long keywordId,
+                      String keywordName,
+                      String longSummary,
+                      List<ArticleDto> articles,
+                      List<String> relatedKeywords,
+                      LocalDateTime createdDate) {
+
     public static NewsDto from(News news) {
         return new NewsDto(news.getKeywordId(),
                 news.getKeywordName(),
@@ -17,6 +24,7 @@ public record NewsDto(Long keywordId, String keywordName, String longSummary, Li
                                 article.getSummary()
                         ))
                         .toList(),
+                Arrays.asList(news.getRelated_keyword()),
                 news.getCreatedDate());
     }
 }

--- a/src/test/java/com/palangwi/soup/news/controller/NewsControllerTest.java
+++ b/src/test/java/com/palangwi/soup/news/controller/NewsControllerTest.java
@@ -40,6 +40,7 @@ class NewsControllerTest extends IntegrationTestSupport {
     private String keywordName;
     private String startDate;
     private String endDate;
+    private List<String> relatedKeywords;
 
     @BeforeEach
     void setUp() {
@@ -47,7 +48,7 @@ class NewsControllerTest extends IntegrationTestSupport {
         keywordName = "인공지능";
         startDate = "2025-06-01";
         endDate = "2025-06-02";
-
+        relatedKeywords = List.of("AI", "LLM", "OpenAI");
         articles = List.of(
                 new ArticleDto("인공지능 뉴스 1", "https://news.com/1", "AI 요약 1"),
                 new ArticleDto("인공지능 뉴스 2", "https://news.com/2", "AI 요약 2")
@@ -58,6 +59,7 @@ class NewsControllerTest extends IntegrationTestSupport {
                 keywordName,
                 "긴 요약",
                 articles,
+                relatedKeywords,
                 LocalDateTime.of(2025, 6, 1, 6, 0)
         );
 
@@ -75,13 +77,13 @@ class NewsControllerTest extends IntegrationTestSupport {
 
         //when && then
         mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/news")
-                .param("keywordId", String.valueOf(keywordId))
-                .param("startDate", startDate)
-                .param("endDate", endDate)
-                .param("page", "0")
-                .param("size", "20")
-                .param("sort", "createdDate,DESC")
-                .contentType(MediaType.APPLICATION_JSON))
+                        .param("keywordId", String.valueOf(keywordId))
+                        .param("startDate", startDate)
+                        .param("endDate", endDate)
+                        .param("page", "0")
+                        .param("size", "20")
+                        .param("sort", "createdDate,DESC")
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -108,7 +110,7 @@ class NewsControllerTest extends IntegrationTestSupport {
 
         //when && then
         mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/news/{newsId}", newsId)
-                .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -116,7 +118,11 @@ class NewsControllerTest extends IntegrationTestSupport {
                 .andExpect(jsonPath("$.data.longSummary").value("긴 요약"))
                 .andExpect(jsonPath("$.data.articles[0].title").value("인공지능 뉴스 1"))
                 .andExpect(jsonPath("$.data.articles[0].url").value("https://news.com/1"))
-                .andExpect(jsonPath("$.data.articles[0].summary").value("AI 요약 1"));
+                .andExpect(jsonPath("$.data.articles[0].summary").value("AI 요약 1"))
+                .andExpect(jsonPath("$.data.relatedKeywords[0]").value("AI"))
+                .andExpect(jsonPath("$.data.relatedKeywords[1]").value("LLM"))
+                .andExpect(jsonPath("$.data.relatedKeywords[2]").value("OpenAI"));
+
 
         verify(newsService).getNewsDetailInfo(newsId);
     }


### PR DESCRIPTION
## 변경 사항 요약
- News 도메인 모델에 relatedKeywords 필드 추가
- NewsDto 및 뉴스 관련 테스트에서 relatedKeywords 필드 사용

## 주요 변경 내용
- News.java 파일에 relatedKeywords라는 List<String> 필드가 추가됨
- NewsDto.java 파일에서 관련 키워드를 포함하도록 데이터 전송 객체가 수정됨
- NewsControllerTest.java 파일에 테스트 데이터로 relatedKeywords 추가 및 검증 로직 포함