### PR TITLE
fix: restDocs 설정 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,9 @@ asciidoctor {
     inputs.dir snippetsDir
     configurations 'asciidoctorExt'
     dependsOn test
+
+    baseDirFollowsSourceFile()
+
     attributes 'snippets': snippetsDir
 }
 


### PR DESCRIPTION
## 변경 사항 요약
- build.gradle 파일에 baseDirFollowsSourceFile() 메서드 추가

## 주요 변경 내용
- baseDirFollowsSourceFile() 메서드는 소스 파일의 기반 디렉토리를 따르도록 설정 (파일: build.gradle)