### PR TITLE
docs: Add comprehensive JWT authentication documentation to REST Docs

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -1,13 +1,124 @@
 [[auth]]
-== Auth
+== 🔐 Auth
+
+=== 인증 개요
+
+이 API는 **JWT 기반 인증**을 사용하며, HTTP-only 쿠키를 통해 토큰을 전달합니다.
+
+==== 토큰 종류
+
+* **Access Token**: API 요청 인증에 사용 (유효기간: 7일)
+* **Refresh Token**: 새로운 Access Token 발급에 사용 (유효기간: 14일)
+
+==== 인증 플로우
+
+1. 사용자가 OAuth2(Google/Kakao)를 통해 로그인
+2. 서버가 `access_token`과 `refresh_token`을 쿠키로 발급
+3. 클라이언트는 이후 요청에 쿠키를 자동으로 포함 (브라우저가 자동 처리)
+4. Access Token 만료 시, `/auth/refresh` 엔드포인트로 새 토큰 발급
+
+==== 쿠키 형식
+
+[cols="2,2,2,4"]
+|===
+|쿠키 이름|타입|유효기간|용도
+
+|`access_token`
+|JWT Token
+|7일
+|API 요청 인증
+
+|`refresh_token`
+|UUID 문자열
+|14일
+|Access Token 갱신
+|===
+
+TIP: 쿠키는 `HttpOnly`, `Secure`, `SameSite=None` 속성으로 설정되어 안전하게 관리됩니다.
+
+==== JWT Claims 구조
+
+Access Token에 포함된 정보:
+
+[source,json]
+----
+{
+  "userKey": 1,
+  "roles": ["USER"],
+  "iat": 1234567890,
+  "iss": "soup-api"
+}
+----
+
+* `userKey`: 사용자 ID (Long)
+* `roles`: 사용자 권한 배열
+* `iat`: 토큰 발급 시간 (Unix timestamp)
+* `iss`: 토큰 발급자
+
+==== 보호된 엔드포인트
+
+`/api/v1/*` 하위 모든 엔드포인트는 인증이 필요합니다. (예외: `/health`, `/users/check-nickname`)
+
+**요청**: `access_token` 쿠키 포함 필수 +
+**실패 응답**: 401 Unauthorized
+
+==== 에러 응답
+
+===== 401 Unauthorized (토큰 없음/유효하지 않음)
+
+[source,json]
+----
+{
+  "success": false,
+  "data": null,
+  "error": {
+    "message": "Unauthorized",
+    "status": 401
+  }
+}
+----
+
+===== 403 Forbidden (권한 부족)
+
+[source,json]
+----
+{
+  "success": false,
+  "data": null,
+  "error": {
+    "message": "Forbidden",
+    "status": 403
+  }
+}
+----
+
+WARNING: 만료된 토큰으로 요청 시 401 에러가 발생합니다. `/auth/refresh`로 토큰을 갱신하세요.
+
+'''
 
 === 토큰 재발급
 
 ==== HTTP Request
 include::{snippets}/auth-refresh/http-request.adoc[]
 
+==== Request Cookies
+include::{snippets}/auth-refresh/request-cookies.adoc[]
+
 ==== HTTP Response
 include::{snippets}/auth-refresh/http-response.adoc[]
+
+==== Response Cookies
+
+[cols="2,3"]
+|===
+|쿠키 이름|설명
+
+|`access_token`
+|새로 발급된 JWT Access Token (유효기간: 7일)
+
+|`refresh_token`
+|새로 발급된 Refresh Token (유효기간: 14일)
+|===
 
 ==== Response Fields
 include::{snippets}/auth-refresh/response-fields.adoc[]
@@ -22,8 +133,26 @@ include::{snippets}/auth-refresh/curl-request.adoc[]
 ==== HTTP Request
 include::{snippets}/auth-logout/http-request.adoc[]
 
+==== Request Cookies
+include::{snippets}/auth-logout/request-cookies.adoc[]
+
 ==== HTTP Response
 include::{snippets}/auth-logout/http-response.adoc[]
+
+==== Response Cookies
+
+[cols="2,3"]
+|===
+|쿠키 이름|설명
+
+|`access_token`
+|삭제된 Access Token (MaxAge=0)
+
+|`refresh_token`
+|삭제된 Refresh Token (MaxAge=0)
+|===
+
+NOTE: 로그아웃 시 모든 토큰 쿠키가 삭제되며, Refresh Token은 Redis에서도 무효화됩니다.
 
 ==== Response Fields
 include::{snippets}/auth-logout/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -31,6 +31,11 @@ include::admin-keyword.adoc[]
 
 include::user.adoc[]
 
+[[keywords]]
+== Keywords
+
+include::keywords.adoc[]
+
 [[auth]]
 == Auth
 

--- a/src/docs/asciidoc/keywords.adoc
+++ b/src/docs/asciidoc/keywords.adoc
@@ -1,0 +1,132 @@
+[[keywords]]
+== 🔑 Keywords
+
+NOTE: 모든 Keyword API는 인증이 필요합니다. 요청 시 `access_token` 쿠키를 포함해야 합니다.
+
+=== 키워드 목록 조회
+
+🔐 **인증 필요**: `access_token` 쿠키
+
+==== HTTP Request
+include::{snippets}/keyword-list/http-request.adoc[]
+
+==== Request Cookies
+include::{snippets}/keyword-list/request-cookies.adoc[]
+
+==== Query Parameters
+include::{snippets}/keyword-list/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/keyword-list/http-response.adoc[]
+
+==== Response Fields
+include::{snippets}/keyword-list/response-fields.adoc[]
+
+==== Curl Request
+include::{snippets}/keyword-list/curl-request.adoc[]
+
+'''
+
+=== 키워드 검색
+
+🔐 **인증 필요**: `access_token` 쿠키
+
+사용자가 키워드를 검색하고 구독 여부를 확인할 수 있습니다.
+
+==== HTTP Request
+include::{snippets}/keyword-search/http-request.adoc[]
+
+==== Request Cookies
+include::{snippets}/keyword-search/request-cookies.adoc[]
+
+==== Query Parameters
+include::{snippets}/keyword-search/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/keyword-search/http-response.adoc[]
+
+==== Response Fields
+include::{snippets}/keyword-search/response-fields.adoc[]
+
+==== Curl Request
+include::{snippets}/keyword-search/curl-request.adoc[]
+
+'''
+
+=== 키워드 구독
+
+🔐 **인증 필요**: `access_token` 쿠키
+
+특정 키워드를 구독하여 관련 뉴스를 이메일로 받을 수 있습니다.
+
+==== HTTP Request
+include::{snippets}/keyword-subscribe/http-request.adoc[]
+
+==== Request Cookies
+include::{snippets}/keyword-subscribe/request-cookies.adoc[]
+
+==== Request Fields
+include::{snippets}/keyword-subscribe/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/keyword-subscribe/http-response.adoc[]
+
+==== Response Fields
+include::{snippets}/keyword-subscribe/response-fields.adoc[]
+
+==== Curl Request
+include::{snippets}/keyword-subscribe/curl-request.adoc[]
+
+'''
+
+=== 키워드 구독 해제
+
+🔐 **인증 필요**: `access_token` 쿠키
+
+구독한 키워드를 해제합니다.
+
+==== HTTP Request
+include::{snippets}/keyword-unsubscribe/http-request.adoc[]
+
+==== Request Cookies
+include::{snippets}/keyword-unsubscribe/request-cookies.adoc[]
+
+==== Path Parameters
+include::{snippets}/keyword-unsubscribe/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/keyword-unsubscribe/http-response.adoc[]
+
+==== Response Fields
+include::{snippets}/keyword-unsubscribe/response-fields.adoc[]
+
+==== Curl Request
+include::{snippets}/keyword-unsubscribe/curl-request.adoc[]
+
+'''
+
+=== 새로운 키워드 요청
+
+🔐 **인증 필요**: `access_token` 쿠키
+
+시스템에 없는 키워드를 관리자에게 요청할 수 있습니다.
+
+TIP: 요청한 키워드는 관리자 승인 후 사용 가능합니다.
+
+==== HTTP Request
+include::{snippets}/keyword-request/http-request.adoc[]
+
+==== Request Cookies
+include::{snippets}/keyword-request/request-cookies.adoc[]
+
+==== Request Fields
+include::{snippets}/keyword-request/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/keyword-request/http-response.adoc[]
+
+==== Response Fields
+include::{snippets}/keyword-request/response-fields.adoc[]
+
+==== Curl Request
+include::{snippets}/keyword-request/curl-request.adoc[]

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -1,10 +1,17 @@
 [[user]]
-== User
+== 👤 User
+
+NOTE: 모든 User API는 인증이 필요합니다. 요청 시 `access_token` 쿠키를 포함해야 합니다.
 
 === 사용자 초기 설정
 
+🔐 **인증 필요**: `access_token` 쿠키
+
 ==== HTTP Request
 include::{snippets}/user-init/http-request.adoc[]
+
+==== Request Cookies
+include::{snippets}/user-init/request-cookies.adoc[]
 
 ==== Request Fields
 include::{snippets}/user-init/request-fields.adoc[]
@@ -22,8 +29,13 @@ include::{snippets}/user-init/curl-request.adoc[]
 
 === 사용자 정보 수정
 
+🔐 **인증 필요**: `access_token` 쿠키
+
 ==== HTTP Request
 include::{snippets}/user-update/http-request.adoc[]
+
+==== Request Cookies
+include::{snippets}/user-update/request-cookies.adoc[]
 
 ==== Request Fields
 include::{snippets}/user-update/request-fields.adoc[]
@@ -41,8 +53,13 @@ include::{snippets}/user-update/curl-request.adoc[]
 
 === 사용자 정보 조회
 
+🔐 **인증 필요**: `access_token` 쿠키
+
 ==== HTTP Request
 include::{snippets}/user-info/http-request.adoc[]
+
+==== Request Cookies
+include::{snippets}/user-info/request-cookies.adoc[]
 
 ==== HTTP Response
 include::{snippets}/user-info/http-response.adoc[]
@@ -76,8 +93,15 @@ include::{snippets}/user-check-nickname/curl-request.adoc[]
 
 === 회원 탈퇴
 
+🔐 **인증 필요**: `access_token` 쿠키
+
+WARNING: 회원 탈퇴 시 모든 사용자 데이터가 삭제되며 복구할 수 없습니다.
+
 ==== HTTP Request
 include::{snippets}/user-delete/http-request.adoc[]
+
+==== Request Cookies
+include::{snippets}/user-delete/request-cookies.adoc[]
 
 ==== Request Fields
 include::{snippets}/user-delete/request-fields.adoc[]
@@ -95,8 +119,13 @@ include::{snippets}/user-delete/curl-request.adoc[]
 
 === 내 키워드 목록 조회
 
+🔐 **인증 필요**: `access_token` 쿠키
+
 ==== HTTP Request
 include::{snippets}/user-my-keywords/http-request.adoc[]
+
+==== Request Cookies
+include::{snippets}/user-my-keywords/request-cookies.adoc[]
 
 ==== Query Parameters
 include::{snippets}/user-my-keywords/query-parameters.adoc[]

--- a/src/test/java/com/palangwi/soup/keyword/controller/KeywordControllerDocsTest.java
+++ b/src/test/java/com/palangwi/soup/keyword/controller/KeywordControllerDocsTest.java
@@ -17,6 +17,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import jakarta.servlet.http.Cookie;
+
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -25,6 +27,8 @@ import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -52,11 +56,15 @@ public class KeywordControllerDocsTest extends RestDocsSupport {
 
         // when & then
         mockMvc.perform(get("/api/v1/keywords")
+                .cookie(new Cookie("access_token", "sample-jwt-access-token"))
                 .param("page", "0")
                 .param("size", "20"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("keyword-list",
+                        requestCookies(
+                                cookieWithName("access_token").description("인증을 위한 JWT Access Token")
+                        ),
                         queryParameters(
                                 parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
                                 parameterWithName("size").description("페이지 크기").optional(),
@@ -92,12 +100,16 @@ public class KeywordControllerDocsTest extends RestDocsSupport {
 
         // when & then
         mockMvc.perform(get("/api/v1/keywords/search")
+                .cookie(new Cookie("access_token", "sample-jwt-access-token"))
                 .param("keyword", "테스트")
                 .param("page", "0")
                 .param("size", "20"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("keyword-search",
+                        requestCookies(
+                                cookieWithName("access_token").description("인증을 위한 JWT Access Token")
+                        ),
                         queryParameters(
                                 parameterWithName("keyword").description("검색할 키워드 (1-100자)"),
                                 parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
@@ -129,11 +141,15 @@ public class KeywordControllerDocsTest extends RestDocsSupport {
 
         // when & then
         mockMvc.perform(post("/api/v1/keywords/subscriptions")
+                .cookie(new Cookie("access_token", "sample-jwt-access-token"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(requestDto)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("keyword-subscribe",
+                        requestCookies(
+                                cookieWithName("access_token").description("인증을 위한 JWT Access Token")
+                        ),
                         requestFields(
                                 fieldWithPath("keywordId").type(JsonFieldType.NUMBER).description("구독할 키워드 ID")),
                         responseFields(
@@ -152,10 +168,14 @@ public class KeywordControllerDocsTest extends RestDocsSupport {
         given(keywordService.unsubscribeKeyword(anyLong())).willReturn(response);
 
         // when & then
-        mockMvc.perform(post("/api/v1/keywords/subscriptions/{subscriptionId}", 1L))
+        mockMvc.perform(post("/api/v1/keywords/subscriptions/{subscriptionId}", 1L)
+                        .cookie(new Cookie("access_token", "sample-jwt-access-token")))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("keyword-unsubscribe",
+                        requestCookies(
+                                cookieWithName("access_token").description("인증을 위한 JWT Access Token")
+                        ),
                         pathParameters(
                                 parameterWithName("subscriptionId").description("구독 ID")),
                         responseFields(
@@ -178,11 +198,15 @@ public class KeywordControllerDocsTest extends RestDocsSupport {
 
         // when & then
         mockMvc.perform(post("/api/v1/keywords/request")
+                .cookie(new Cookie("access_token", "sample-jwt-access-token"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(requestDto)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("keyword-request",
+                        requestCookies(
+                                cookieWithName("access_token").description("인증을 위한 JWT Access Token")
+                        ),
                         requestFields(
                                 fieldWithPath("keyword").type(JsonFieldType.STRING)
                                         .description("요청할 키워드 (필수, 비어있지 않아야 함)")),

--- a/src/test/java/com/palangwi/soup/user/controller/AuthControllerDocsTest.java
+++ b/src/test/java/com/palangwi/soup/user/controller/AuthControllerDocsTest.java
@@ -8,12 +8,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import jakarta.servlet.http.Cookie;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,10 +38,14 @@ public class AuthControllerDocsTest extends RestDocsSupport {
         doNothing().when(authService).reissueAccessToken(any(HttpServletRequest.class), any(HttpServletResponse.class));
 
         // when & then
-        mockMvc.perform(post("/api/v1/auth/refresh"))
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new Cookie("refresh_token", "sample-refresh-token-uuid")))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("auth-refresh",
+                        requestCookies(
+                                cookieWithName("refresh_token").description("새로운 Access Token을 발급받기 위한 Refresh Token")
+                        ),
                         responseFields(
                                 fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
                                 fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터 (null)"),
@@ -53,10 +61,14 @@ public class AuthControllerDocsTest extends RestDocsSupport {
         doNothing().when(authService).logout(any(HttpServletRequest.class), any(HttpServletResponse.class));
 
         // when & then
-        mockMvc.perform(post("/api/v1/auth/logout"))
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .cookie(new Cookie("refresh_token", "sample-refresh-token-uuid")))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("auth-logout",
+                        requestCookies(
+                                cookieWithName("refresh_token").description("무효화할 Refresh Token (Redis에서 삭제됨)")
+                        ),
                         responseFields(
                                 fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
                                 fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터 (null)"),

--- a/src/test/java/com/palangwi/soup/user/controller/UserControllerDocsTest.java
+++ b/src/test/java/com/palangwi/soup/user/controller/UserControllerDocsTest.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import jakarta.servlet.http.Cookie;
+
 import java.time.LocalDate;
 import java.util.List;
 
@@ -24,6 +26,8 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -61,11 +65,15 @@ public class UserControllerDocsTest extends RestDocsSupport {
 
         // when & then
         mockMvc.perform(post("/api/v1/users/init")
+                        .cookie(new Cookie("access_token", "sample-jwt-access-token"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("user-init",
+                        requestCookies(
+                                cookieWithName("access_token").description("인증을 위한 JWT Access Token")
+                        ),
                         requestFields(
                                 fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
                                 fieldWithPath("gender").type(JsonFieldType.STRING).description("성별 (MALE, FEMALE)"),
@@ -110,11 +118,15 @@ public class UserControllerDocsTest extends RestDocsSupport {
 
         // when & then
         mockMvc.perform(patch("/api/v1/users")
+                        .cookie(new Cookie("access_token", "sample-jwt-access-token"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("user-update",
+                        requestCookies(
+                                cookieWithName("access_token").description("인증을 위한 JWT Access Token")
+                        ),
                         requestFields(
                                 fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임 (선택, 2-20자)").optional(),
                                 fieldWithPath("profileImageUrl").type(JsonFieldType.STRING).description("프로필 이미지 URL (선택)").optional()
@@ -155,10 +167,14 @@ public class UserControllerDocsTest extends RestDocsSupport {
         given(userService.getUserInfo(anyLong())).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/v1/users"))
+        mockMvc.perform(get("/api/v1/users")
+                        .cookie(new Cookie("access_token", "sample-jwt-access-token")))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("user-info",
+                        requestCookies(
+                                cookieWithName("access_token").description("인증을 위한 JWT Access Token")
+                        ),
                         responseFields(
                                 fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
                                 fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
@@ -208,11 +224,15 @@ public class UserControllerDocsTest extends RestDocsSupport {
 
         // when & then
         mockMvc.perform(post("/api/v1/users/delete")
+                        .cookie(new Cookie("access_token", "sample-jwt-access-token"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("user-delete",
+                        requestCookies(
+                                cookieWithName("access_token").description("인증을 위한 JWT Access Token")
+                        ),
                         requestFields(
                                 fieldWithPath("reason").type(JsonFieldType.STRING).description("탈퇴 사유")
                         ),
@@ -238,11 +258,15 @@ public class UserControllerDocsTest extends RestDocsSupport {
 
         // when & then
         mockMvc.perform(get("/api/v1/users/me/keywords")
+                        .cookie(new Cookie("access_token", "sample-jwt-access-token"))
                         .param("page", "0")
                         .param("size", "20"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("user-my-keywords",
+                        requestCookies(
+                                cookieWithName("access_token").description("인증을 위한 JWT Access Token")
+                        ),
                         queryParameters(
                                 parameterWithName("page").description("페이지 번호 (0부터 시작)"),
                                 parameterWithName("size").description("페이지 크기")


### PR DESCRIPTION
## 변경 사항 요약
- JWT 기반 인증 API 문서 업데이트
- Access Token과 Refresh Token 사용 설명 추가

## 주요 변경 내용
- 인증 개요와 플로우 설명 추가 (파일: src/docs/asciidoc/auth.adoc)
- Request Cookies 관련 내용 추가 (파일: src/docs/asciidoc/keywords.adoc 및 user.adoc)
- Keywords 요청 및 사용자 요청에 대한 인증 필요성 강조 (파일: src/docs/asciidoc/keywords.adoc, user.adoc)
- 테스트 코드에서 access_token 및 refresh_token 쿠키 관련 정보 추가 (파일: src/test/java/com/palangwi/soup/keyword/controller/KeywordControllerDocsTest.java, AuthControllerDocsTest.java, UserControllerDocsTest.java)