### PR TITLE
fix: 구독해제한 키워드 다시 구독 시 발생하는 에러 해결

### DIFF
--- a/src/main/java/com/palangwi/soup/keyword/service/KeywordServiceImpl.java
+++ b/src/main/java/com/palangwi/soup/keyword/service/KeywordServiceImpl.java
@@ -157,7 +157,7 @@ public class KeywordServiceImpl implements KeywordService {
     }
 
     private UserKeyword findOrCreateUserKeyword(User user, Long keywordId) {
-        return userKeywordRepository.findSubscribedByUserIdAndKeywordId(user.getId(), keywordId)
+        return userKeywordRepository.findByUserIdAndKeywordId(user.getId(), keywordId)
                 .orElseGet(() -> {
                     Keyword keyword = keywordRepository.findById(keywordId)
                             .orElseThrow(KeywordNotFoundException::new);

--- a/src/main/java/com/palangwi/soup/subscription/domain/UserKeywords.java
+++ b/src/main/java/com/palangwi/soup/subscription/domain/UserKeywords.java
@@ -19,7 +19,11 @@ public class UserKeywords {
     private List<UserKeyword> userKeywordList = new ArrayList<>();
 
     public void subscribe(User user, Keyword keyword) {
-        userKeywordList.add(UserKeyword.create(user, keyword));
+        findByKeyword(keyword)
+                .ifPresentOrElse(
+                        UserKeyword::subscribe,
+                        () -> userKeywordList.add(UserKeyword.create(user, keyword))
+                );
     }
 
     public void unSubscribe(Keyword keyword) {

--- a/src/main/java/com/palangwi/soup/subscription/repository/UserKeywordRepository.java
+++ b/src/main/java/com/palangwi/soup/subscription/repository/UserKeywordRepository.java
@@ -44,5 +44,7 @@ public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> 
             @Param("keywordIds") List<Long> keywordIds
     );
 
+    Optional<UserKeyword> findByUserIdAndKeywordId(Long userId, Long keywordId);
+
     boolean existsByUser_IdAndKeyword_Id(Long userId, Long keywordId);
 }


### PR DESCRIPTION
## 변경 사항 요약
- UserKeyword 관련 메서드를 추가 및 변경
- 특정 사용자의 키워드 구독 관리 기능 개선

## 주요 변경 내용
- KeywordServiceImpl에서 userKeywordRepository를 통해 사용자와 키워드를 기반으로 한 정보를 조회하는 메서드 추가 (파일: KeywordServiceImpl.java)
- UserKeywords 클래스에서 키워드를 기반으로 사용자 키워드를 처리하는 로직 수정 (파일: UserKeywords.java)
- UserKeywordRepository에서 사용자 ID와 키워드 ID로 사용자 키워드를 조회하는 쿼리 메서드 추가 (파일: UserKeywordRepository.java)