### PR TITLE
fix: restrict admin APIs to admin role

### DIFF
--- a/src/main/java/com/palangwi/soup/common/config/SecurityConfig.java
+++ b/src/main/java/com/palangwi/soup/common/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/users/check-nickname").permitAll()
                         .requestMatchers("/login/oauth2/code/**").permitAll()
                         .requestMatchers("/actuator/**").hasRole("ADMIN")
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/**").authenticated())
                 .addFilterBefore(jwtAuthenticationTokenFilter, UsernamePasswordAuthenticationFilter.class)
                 .oauth2Login(configurer -> configurer

--- a/src/test/java/com/palangwi/soup/common/config/SecurityConfigTest.java
+++ b/src/test/java/com/palangwi/soup/common/config/SecurityConfigTest.java
@@ -1,0 +1,30 @@
+package com.palangwi.soup.common.config;
+
+import com.palangwi.soup.IntegrationTestSupport;
+import com.palangwi.soup.common.security.WithMockJwtAuthentication;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class SecurityConfigTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("관리자 API는 일반 사용자 접근을 거부한다.")
+    @WithMockJwtAuthentication(role = "ROLE_USER")
+    void adminApiRequiresAdminRole() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/keyword")
+                        .param("status", "ACTIVE"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("관리자 API는 관리자 접근을 허용한다.")
+    @WithMockJwtAuthentication(role = "ROLE_ADMIN")
+    void adminApiAllowsAdminRole() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/keyword")
+                        .param("status", "ACTIVE"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## 변경 사항 요약
- 관리자 API의 접근 제어가 추가됨
- 관리자 역할에 따른 테스트 케이스도 작성됨

## 주요 변경 내용
- SecurityConfig.java 파일에서 관리자 API 경로에 ADMIN 역할 요구 추가 (파일: SecurityConfig.java)
- SecurityConfigTest.java 파일에서 관리자 API 접근 제어에 대한 테스트 케이스 추가 (파일: SecurityConfigTest.java)