### PR TITLE
ci: skip Discord notifications without webhook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
     steps:
       - uses: actions/checkout@v4
@@ -44,10 +46,11 @@ jobs:
           path: build/reports/
 
       - name: Notify Discord on Build Success
-        if: success()
+        if: success() && env.DISCORD_WEBHOOK_URL != ''
         uses: fjogeleit/http-request-action@v1.14.0
+        continue-on-error: true
         with:
-          url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"
           customHeaders: '{"Content-Type": "application/json"}'
           data: |
@@ -56,10 +59,11 @@ jobs:
             }
 
       - name: Notify Discord on Build Failure
-        if: failure()
+        if: failure() && env.DISCORD_WEBHOOK_URL != ''
         uses: fjogeleit/http-request-action@v1.14.0
+        continue-on-error: true
         with:
-          url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"
           customHeaders: '{"Content-Type": "application/json"}'
           data: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Notify Discord on Deploy Success
         if: success() && env.DISCORD_WEBHOOK_URL != ''
         uses: fjogeleit/http-request-action@v1.14.0
+        continue-on-error: true
         with:
           url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"
@@ -109,6 +110,7 @@ jobs:
       - name: Notify Discord on Deploy Failure
         if: failure() && env.DISCORD_WEBHOOK_URL != ''
         uses: fjogeleit/http-request-action@v1.14.0
+        continue-on-error: true
         with:
           url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"

--- a/.github/workflows/pr-notifier.yml
+++ b/.github/workflows/pr-notifier.yml
@@ -12,12 +12,15 @@ on:
 jobs:
   notify-discord:
     runs-on: ubuntu-latest
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
     steps:
       - name: Send PR opened/reopened notification
-        if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
+        if: env.DISCORD_WEBHOOK_URL != '' && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
         uses: fjogeleit/http-request-action@v1.14.0
+        continue-on-error: true
         with:
-          url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"
           customHeaders: '{"Content-Type": "application/json"}'
           data: |
@@ -26,10 +29,11 @@ jobs:
             }
 
       - name: Send PR review notification
-        if: github.event_name == 'pull_request_review' && github.event.review.state != 'commented'
+        if: env.DISCORD_WEBHOOK_URL != '' && github.event_name == 'pull_request_review' && github.event.review.state != 'commented'
         uses: fjogeleit/http-request-action@v1.14.0
+        continue-on-error: true
         with:
-          url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"
           customHeaders: '{"Content-Type": "application/json"}'
           data: |
@@ -38,10 +42,11 @@ jobs:
             }
 
       - name: Send PR merged notification
-        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: env.DISCORD_WEBHOOK_URL != '' && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         uses: fjogeleit/http-request-action@v1.14.0
+        continue-on-error: true
         with:
-          url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"
           customHeaders: '{"Content-Type": "application/json"}'
           data: |
@@ -50,10 +55,11 @@ jobs:
             }
 
       - name: Send PR comment notification (issue comment)
-        if: github.event_name == 'issue_comment' && github.event.issue.pull_request != null
+        if: env.DISCORD_WEBHOOK_URL != '' && github.event_name == 'issue_comment' && github.event.issue.pull_request != null
         uses: fjogeleit/http-request-action@v1.14.0
+        continue-on-error: true
         with:
-          url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"
           customHeaders: '{"Content-Type": "application/json"}'
           data: |
@@ -62,10 +68,11 @@ jobs:
             }
 
       - name: Send PR comment notification (review comment)
-        if: github.event_name == 'pull_request_review_comment'
+        if: env.DISCORD_WEBHOOK_URL != '' && github.event_name == 'pull_request_review_comment'
         uses: fjogeleit/http-request-action@v1.14.0
+        continue-on-error: true
         with:
-          url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"
           customHeaders: '{"Content-Type": "application/json"}'
           data: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
   publish:
     name: Test and Publish
     runs-on: ubuntu-latest
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
     steps:
       - uses: actions/checkout@v4
@@ -57,10 +59,11 @@ jobs:
             ${{ secrets.DOCKER_HUB_USERNAME }}/soup-backend:${{ github.sha }}
 
       - name: Notify Discord on Publish Success
-        if: success()
+        if: success() && env.DISCORD_WEBHOOK_URL != ''
         uses: fjogeleit/http-request-action@v1.14.0
+        continue-on-error: true
         with:
-          url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"
           customHeaders: |
             Content-Type: application/json
@@ -86,10 +89,11 @@ jobs:
             }
 
       - name: Notify Discord on Publish Failure
-        if: failure()
+        if: failure() && env.DISCORD_WEBHOOK_URL != ''
         uses: fjogeleit/http-request-action@v1.14.0
+        continue-on-error: true
         with:
-          url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"
           customHeaders: |
             Content-Type: application/json


### PR DESCRIPTION
## 변경 사항 요약
- GitHub Actions 워크플로우 파일에 Discord 웹훅 URL 환경 변수를 추가함.
- 성공 및 실패 시 특정 이벤트에 대한 알림을 Discord로 전송하도록 설정.

## 주요 변경 내용
- .github/workflows/ci.yml에서 Discord 웹훅 URL을 사용하여 빌드 성공 및 실패 알림을 설정 (라인 19, 49, 62).
- .github/workflows/deploy.yml에서 계속 오류를 허용하도록 설정 (라인 78, 113).
- .github/workflows/pr-notifier.yml에서 다양한 Pull Request 이벤트에 따라 Discord 웹훅을 통해 알림을 보냄 (라인 16, 19, 32, 45, 58, 71).
- .github/workflows/publish.yml에서 빌드 성공 및 실패에 대한 Discord 알림 설정 (라인 20, 62, 92).