### PR TITLE
ci: fix backend Discord header format

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,8 +79,7 @@ jobs:
         with:
           url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"
-          customHeaders: |
-            Content-Type: application/json
+          customHeaders: '{"Content-Type": "application/json"}'
           data: |
             {
               "embeds": [{
@@ -114,8 +113,7 @@ jobs:
         with:
           url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"
-          customHeaders: |
-            Content-Type: application/json
+          customHeaders: '{"Content-Type": "application/json"}'
           data: |
             {
               "embeds": [{

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,8 +65,7 @@ jobs:
         with:
           url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"
-          customHeaders: |
-            Content-Type: application/json
+          customHeaders: '{"Content-Type": "application/json"}'
           data: |
             {
               "embeds": [{
@@ -95,8 +94,7 @@ jobs:
         with:
           url: ${{ env.DISCORD_WEBHOOK_URL }}
           method: "POST"
-          customHeaders: |
-            Content-Type: application/json
+          customHeaders: '{"Content-Type": "application/json"}'
           data: |
             {
               "embeds": [{


### PR DESCRIPTION
## 변경 사항 요약
- HTTP 요청에 대한 Content-Type 헤더가 JSON 형식으로 설정됨
- 두 개의 워크플로우 파일에서 해당 변경이 이루어짐

## 주요 변경 내용
- .github/workflows/deploy.yml 파일의 82와 116라인에서 customHeaders가 변경됨
- .github/workflows/publish.yml 파일의 68과 97라인에서 customHeaders가 변경됨