### PR TITLE
fix: make admin status filters optional

### DIFF
--- a/src/main/java/com/palangwi/soup/admin/controller/AdminKeywordController.java
+++ b/src/main/java/com/palangwi/soup/admin/controller/AdminKeywordController.java
@@ -28,7 +28,7 @@ public class AdminKeywordController {
     @GetMapping
     public ApiResult<KeywordListResponseDto> getAllKeywords(
             @AuthenticationPrincipal JwtAuthentication userInfo,
-            @Valid @RequestParam(name = "status") String status,
+            @Valid @RequestParam(name = "status", required = false) String status,
             @PageableDefault(size = 10, sort = "createdDate", direction = Direction.DESC) Pageable pageable) {
         return success(adminKeywordService.getAllKeywordList(status, pageable));
     }

--- a/src/main/java/com/palangwi/soup/admin/controller/AdminRequestedKeywordController.java
+++ b/src/main/java/com/palangwi/soup/admin/controller/AdminRequestedKeywordController.java
@@ -27,7 +27,7 @@ public class AdminRequestedKeywordController {
     @GetMapping
     public ApiResult<AdminKeywordResponseListDto> getRequestedKeyword(
             @AuthenticationPrincipal JwtAuthentication userInfo,
-            @Valid @RequestParam(name = "status") String status,
+            @Valid @RequestParam(name = "status", required = false) String status,
             @PageableDefault(size = 10, sort = "createdDate", direction = Direction.DESC) Pageable pageable) {
         return success(adminKeywordService.getRequestedKeywords(status, pageable));
     }

--- a/src/test/java/com/palangwi/soup/admin/controller/AdminKeywordControllerDocsTest.java
+++ b/src/test/java/com/palangwi/soup/admin/controller/AdminKeywordControllerDocsTest.java
@@ -48,18 +48,17 @@ public class AdminKeywordControllerDocsTest extends RestDocsSupport {
                 1,
                 0
         );
-        given(adminKeywordService.getAllKeywordList(anyString(), any(Pageable.class))).willReturn(response);
+        given(adminKeywordService.getAllKeywordList(nullable(String.class), any(Pageable.class))).willReturn(response);
 
         // when & then
         mockMvc.perform(get("/api/v1/admin/keyword")
-                        .param("status", "ACTIVE")
                         .param("page", "0")
                         .param("size", "10"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("admin-keyword-list",
                         queryParameters(
-                                parameterWithName("status").description("키워드 상태 (ACTIVE, REMOVED)"),
+                                parameterWithName("status").optional().description("키워드 상태 (ACTIVE, INACTIVE, DELETED, PENDING, REJECTED). 생략 시 전체 조회"),
                                 parameterWithName("page").description("페이지 번호 (0부터 시작)"),
                                 parameterWithName("size").description("페이지 크기")
                         ),

--- a/src/test/java/com/palangwi/soup/admin/controller/AdminRequestedKeywordControllerDocsTest.java
+++ b/src/test/java/com/palangwi/soup/admin/controller/AdminRequestedKeywordControllerDocsTest.java
@@ -53,18 +53,17 @@ public class AdminRequestedKeywordControllerDocsTest extends RestDocsSupport {
                 1,
                 0
         );
-        given(adminKeywordService.getRequestedKeywords(anyString(), any(Pageable.class))).willReturn(response);
+        given(adminKeywordService.getRequestedKeywords(nullable(String.class), any(Pageable.class))).willReturn(response);
 
         // when & then
         mockMvc.perform(get("/api/v1/admin/keyword-requests")
-                        .param("status", "PENDING")
                         .param("page", "0")
                         .param("size", "10"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("admin-keyword-requests-list",
                         queryParameters(
-                                parameterWithName("status").description("키워드 상태 (PENDING, APPROVED, REJECTED)"),
+                                parameterWithName("status").optional().description("키워드 상태 (PENDING, ACTIVE, REJECTED 등). 생략 시 전체 조회"),
                                 parameterWithName("page").description("페이지 번호 (0부터 시작)"),
                                 parameterWithName("size").description("페이지 크기")
                         ),


### PR DESCRIPTION
## 변경 사항 요약
- AdminKeywordController와 AdminRequestedKeywordController에서 'status' 파라미터를 추가함.
- 관련 테스트 파일에서 'status' 파라미터에 대한 문서화 업데이트.

## 주요 변경 내용
- 'status' 파라미터를 AdminKeywordController에서 추가 (파일: AdminKeywordController.java)
- 'status' 파라미터를 AdminRequestedKeywordController에서 추가 (파일: AdminRequestedKeywordController.java)
- AdminKeywordControllerDocsTest에서 'status' 파라미터에 대한 문서화 업데이트 (파일: AdminKeywordControllerDocsTest.java)
- AdminRequestedKeywordControllerDocsTest에서 'status' 파라미터에 대한 문서화 업데이트 (파일: AdminRequestedKeywordControllerDocsTest.java)